### PR TITLE
[PR] Complete rework for changes in CV v17.0

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,7 @@ disable=raw-checker-failed,
         use-symbolic-message-instead,
         use-implicit-booleaness-not-comparison-to-string,
         use-implicit-booleaness-not-comparison-to-zero,
-        too_many_lines,
+        too-many-lines,
         # added
         # missing-module-docstring,
         # logging-fstring-interpolation,

--- a/.pylintrc
+++ b/.pylintrc
@@ -16,7 +16,7 @@ bad-names=foo,
 [EXCEPTIONS]
 
 [FORMAT]
-max-line-length=130
+max-line-length=150
 
 [IMPORTS]
 
@@ -34,6 +34,7 @@ disable=raw-checker-failed,
         use-symbolic-message-instead,
         use-implicit-booleaness-not-comparison-to-string,
         use-implicit-booleaness-not-comparison-to-zero,
+        too_many_lines,
         # added
         # missing-module-docstring,
         # logging-fstring-interpolation,

--- a/README.md
+++ b/README.md
@@ -1,42 +1,47 @@
 # Common Voice Dataset Compiler - Common Voice ToolBox
 
-This repository contains python commmand line utilities for pre-calculating the data for [Common Voice Dataset Analyzer](https://github.com/HarikalarKutusu/cv-tbox-dataset-analyzer) (which is actually a viewer) in an offline process.
+This repository contains python command line utilities for pre-calculating the data for [Common Voice Dataset Analyzer](https://github.com/HarikalarKutusu/cv-tbox-dataset-analyzer) (which is actually a viewer) in an offline process.
 To be able to use this, you have to download the datasets yourselves and provide the tsv files and other data (such as clip durations and text-corpora).
-It is a lengthy process using huge amounts of data (in our case it was 42GB uncompressed, without audio files) and you are not expected to use this utility.
+It is a lengthy process using huge amounts of data (in our case it is 274 GB uncompressed after Common Voice v16.1 - i.e. without the audio files) and you are not expected to use this utility.
 We already use it, and you can view the results in the [Common Voice Dataset Analyzer](https://github.com/HarikalarKutusu/cv-tbox-dataset-analyzer).
 
 This code is provided as part of being open-source and as a reference for calculations.
 
 ## Scripts
 
-The first two scripts should be run before the final one. The timings are based on the HW given at the bottom.
+The scripts should be run in the listed order below.
+Location of files among other settings are set in `conf.py` file.
 
 ### split_compile.py
 
 Assumes:
 
-- You have downloaded all datasets from many Common Voice versions
+- You have downloaded all datasets from all Common Voice versions
 - Extracted the tsv files
-- Ran different splitting algorithms on them and kept the results in different directories (e.g. using the ones in [Common Voice Diversity Check](https://github.com/HarikalarKutusu/common-voice-diversity-check)).
-- You ran a script to measure the duration of each mp3 file and saved it into a dataframe (.tsv) as a look-up-table.
+- Ran different splitting algorithms on them and kept the results in different directories (i.e. using the ones in [Common Voice Diversity Check](https://github.com/HarikalarKutusu/common-voice-diversity-check)).
 
 This script reorganizes (compiles) them under this repo to be processed.
 
-This script currently runs on a single process to prevent disk overload, takes 5-6 minutes for 100 locales.
-Should be run with new versions/additions and/or new splitting algorithms.
+This script skips already processed versions/locales, but should be run from scratch if new script algorithm is added.
 
 ### text_corpus_compile.py
 
 Assumes:
 
-- You have a current Common Voice repo clone (to reach the text-corpora)
+- You executed split_compile.py
+- [TODO] common-voice-cache repo
 
-For each locale, this script combines existing files under that language into a single pandas dataframe compatible tsv file, also calculating a normalized version, char count, word count and validity. For normalization and validation it depends on [commonvoice-utils](https://github.com/ftyers/commonvoice-utils) (please see that repo for installation). Some of the languages there do not have this support, so they will not have the whole data.
+With Common Voice v17.0, text corpora is part of the releases. For each locale, this script takes the `validated_sentences.tsv` file; then -whenever possible - pre-calculates a normalized version, tokens in it, char count, word count and validity; it than saves it under `./text-corpus/<lc>/$text_corpus.tsv` file. On consequiteive versions, only the newly sentences get preprocessed and added to it.
 
-The script uses multi-processing, running in 5 processes on a 6 real core notebook, execution takes 5-6 mins for 132 locales.
-Should be ran from time to time to update the data with new strings, e.g. monthly.
+For normalization and validation it depends on [commonvoice-utils](https://github.com/ftyers/commonvoice-utils) (please see that repo for installation). Some of the languages there do not have this support, so they will not have the whole data.
 
-Known issue: String length calculation with unicode locales might be wrong, to be addressed shortly.
+The script uses multi-processing. Should be run from time to time to update the data with new strings, e.g. monthly.
+
+Known issues:
+
+1. String length calculation with unicode locales might be wrong, to be addressed shortly.
+2. Between v14.0 - v16.1, the sentences which are entered though the new write page are NOT in the text-corpora.
+3. The sentences in text corpora might be different in splits, as the CorporaCreator cleans the recorded ones in a multiprocessing (global and some language specific ones). We did not incorporate those cleanings in our code - yet. Some statistics prior to v17.0 should be done from sentences, thus the results might not reflect the correct values because of these changes.
 
 ### final_compile.py
 
@@ -44,19 +49,18 @@ Assumes:
 
 - You ran the two scripts above and have all the data here as specified on the next section.
 
-This script processes all data and calculates some statistics and distributions and saves them in tsv & json formats under the results directory, grouped by languages. Each version's data is kept in a different file, keeping the file sizes at 10k max, so that we can limit the memory needed in the client and probably cache them whenever the client becomes a PWA. We do not include easily calculatable values into these results and leave simple divisions or substractions to the client.
+This script processes all data and calculates statistics and distributions, and saves them in tsv & json formats under the results directory, grouped by languages. Each version's data is kept in a different file, keeping the file sizes small, so that we can limit the memory needed in the client and probably cache them whenever the client becomes a PWA. We do not include easily calculatable values into these results and leave simple divisions or substractions to the client.
 
-Uses multi-processing, running in 5 processes on a 6 real core notebook, takes about 30-31 mins.
-Should be run whenever previous scripts run.
+Uses multi-processing.
 The json results will be copied to the [Common Voice Dataset Analyzer](https://github.com/HarikalarKutusu/cv-tbox-dataset-analyzer).
 
 ### pack_splits.py
 
-Simple script to create `tar.xz` files from training splits (tarin/dev/test) to make them downloadable.
+Simple script to create `tar.xz` files from training splits (train/dev/test) to make them downloadable. It usually points out of the git area, where you could upload it to a server (we currently use Google Drive, after it got big). The files are names in the format `<lc>-<ver>_<algorithm>.tar.xz`
 
 ## Data Structure
 
-.The following structure is under the web/data directory
+The following structure is under the `data` directory
 
 ```txt
 STRUCTURE AT SOURCE
@@ -64,10 +68,16 @@ STRUCTURE AT SOURCE
 clip-durations
   <lc>
     clip_durations.tsv            # Durations of all clips, previousşy calculated using external process during download, with v14.0 it is generated from times.txt file provided in the datasets
-text-corpus                       # Compiled by "text_corpus_compile.py" from fresh Common Voice repository clone
+text-analysis                     # Compiled by "text_corpus_compile.py" from fresh Common Voice repository clone
+  <cvver>                         # eg: "cv-corpus-11.0-2022-09-21"
+    <lc>                          # eg: "tr"
+      tokens*.tsv                 # Results of token frequencies, global and per split - if supported
+      graphemes*.tsv              # Results of grapheme frequencies, global and per split
+      phonemes*.tsv               # Results of phonme frequencies, global and per split - if supported
+      domains*.tsv                # Results of sentence domain frequencies, global and per split - if supported
+text-corpus                       # Compiled and pre-processed by "text_corpus_compile.py"
   <lc>
     $text_corpus.tsv              # Combined text corpus with additional info
-    $tokens.tsv                   # Results of tokenisation (if supported) with frequencies
 voice-corpus
   <cvver>                         # eg: "cv-corpus-11.0-2022-09-21"
     <lc>                          # eg: "tr"
@@ -75,30 +85,32 @@ voice-corpus
       invalidated.tsv
       other.tsv
       reported.tsv
+      unvalidated_sentences.tsv
+      validated_sentences.tsv
       <splitdir>                  # Splitting algorithms: s1, s99, v1, ...
         train.tsv                 # These are splitting algorithm dependent files
         dev.tsv
         test.tsv
-
-FINAL STRUCTURE AT DESTINATION
-
 results
   tsv                               # Created for internal use / further python pandas processing if needed
+    $config.tsv                     # Configuration used cv-tobox-dataset-compiler to be used in upper level applications, such as cv-tbox-dataset-analyzer
     $support_matrix.tsv             # Combined support matrix, keeping what languages/versions/splitting algorithms are supported by the system
-    $text_corpus_stats.tsv          # Combined text-corpus statistics
     <lc>
       <lc>_<ver>_splits.tsv         # eg: "tr_v11.0_splits.tsv", keeps all split statistics of this version of locale dataset.
-  json                              # For being copied into webapp's public/assets/data directory 
-    $support_matrix.json            # Combined support matrix, keeping what languages/versions/splitting algorithms are supported by the system
-    $text_corpus_stats.json         # Combined text-corpus statistics
+      <lc>_<ver>_tc_stats.tsv       # Combined text-corpus statistics global, per bucket and per split - one per version.
+      $reported.tsv                 # Statistics of reported sentences - all versions combined
+  json                              # Same as above, for being copied into webapp's public/assets/data directory 
+    $config.json
+    $support_matrix.json
     <lc>
-      <lc>_<ver>_splits.json        # eg: "tr_v11.0_splits.json", keeps all split statistics of this version of locale dataset.
-      <lc>-<ver>_<algorithm>.tar.xz # eg: "tr_v11.0_s99.tar.xz", compressed split files to download.
+      <lc>_<ver>_splits.json
+      <lc>_<ver>_tc_stats.tsv
+      $reported.json
 ```
 
 ## Setup and Run
 
-Developed and tested on Python 3.8.x but should work on later versions. It is preferred to use a virtual environment.
+Initially developed and tested on Python 3.8.x, but continued on v3.12.x with new type definition possibilities. It is preferred to use a virtual environment.
 
 1. Create venv and activate it
 2. Clone the repo and cd into it
@@ -121,16 +133,111 @@ This will eventually be part of the Common Voice Toolbox's Core, but it will be 
 
 The project status can be found on the [project page](https://github.com/users/HarikalarKutusu/projects/10). Please post [issues and feature requests](https://github.com/HarikalarKutusu/cv-tbox-dataset-compiler/issues), or [Pull Requests](https://github.com/HarikalarKutusu/cv-tbox-dataset-compiler/pulls) to enhance.
 
-### Hardware used for duration measurements
+### Hardware & Performance
 
 We used a development notebook for the timing with the following specs:
 
-- OS: Windows 10x64 21H2
-- CPU: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz (6 cores, 12 treads, but we used 5 actual cores at max, we used HW Turbo button on the notebook)
-- RAM: 16 GB RAM, made sure that we have 5-6 GB empty while running the scripts
-- SSD: CT500P2SSD8 (Crucial P2 500GB 2300-940MB/s NVMe PCI-e M2)
+- Intel i7 8700K 6 core / 12 tread @3.7/4.3 GHz, 48 GB DDR4 RAM @3000 GHz (>32 GB empty)
+- Compressed Data: On an external 8TB Seagate Backup+ HUB w. USB3 (100-110 MB/s, ~60-65 MB/s continuous read)
+- Expanded Data: On an internal Western Digital WD100EMAZ SATA 3 HDD (~90-120 MB/s R/W)
+- Working Data: On system drive 2TB Samsung 990 Pro (w. PCIe v3.0), thus ~3500/3500 MB/s R/W speed
 
-At the end, CPU runs around 50-60% (max %70), RAM is only used higher on large datasets, but SSD -having lower specs- can be overloaded with 100% utilization.
+With multiple huge changes in Common Voice v17.0, we needed to recalculate everthing after substantial code changes.
+We worked on 16 versions (leaving v2 out), all languages in them -total 1336 releases-, 5 splitting algorithms (s1, s99, v1, vw, vx) if they are allowed (vw & vx algorithms is not applied to all), resulting in analysis of 20,234 combinations (version/language/algorithm/all-or-bucket-or-split).
 
-Addition: With v14.0 release, we re-ran the whole set on a i7-8700K / 48 GB / SSD desktop.
-Compiling statistics for 978 datasets, 2927 algorithms, 12693 splits took 0:43:54, 2.7 sec/dataset on the average.
+Here are results:
+
+```text
+$ python .\split_compile.py
+=== cv-tbox-dataset-compiler: Data Algorithms/Splits Collection Process ===
+Preparing directory structures...
+   v1: 100%|█████████████████████████████████████████████████████| 19/19 [00:02<00:00,  7.80 Locale/s]
+   v3: 100%|█████████████████████████████████████████████████████| 29/29 [00:02<00:00, 10.88 Locale/s]
+   v4: 100%|█████████████████████████████████████████████████████| 40/40 [00:04<00:00,  9.55 Locale/s]
+ v5.1: 100%|█████████████████████████████████████████████████████| 54/54 [00:06<00:00,  7.90 Locale/s]
+ v6.1: 100%|█████████████████████████████████████████████████████| 60/60 [00:08<00:00,  7.34 Locale/s]
+ v7.0: 100%|█████████████████████████████████████████████████████| 76/76 [00:11<00:00,  6.45 Locale/s]
+ v8.0: 100%|█████████████████████████████████████████████████████| 87/87 [00:15<00:00,  5.78 Locale/s]
+ v9.0: 100%|█████████████████████████████████████████████████████| 93/93 [00:15<00:00,  5.88 Locale/s]
+v10.0: 100%|█████████████████████████████████████████████████████| 96/96 [00:16<00:00,  5.69 Locale/s]
+v11.0: 100%|████████████████████████████████████████████████████| 100/100 [00:18<00:00,  5.55 Locale/s]
+v12.0: 100%|████████████████████████████████████████████████████| 104/104 [00:18<00:00,  5.61 Locale/s]
+v13.0: 100%|████████████████████████████████████████████████████| 108/108 [00:20<00:00,  5.39 Locale/s]
+v14.0: 100%|████████████████████████████████████████████████████| 112/112 [00:25<00:00,  4.32 Locale/s]
+v15.0: 100%|████████████████████████████████████████████████████| 114/114 [00:27<00:00,  4.07 Locale/s]
+v16.1: 100%|████████████████████████████████████████████████████| 120/120 [00:29<00:00,  4.12 Locale/s]
+v17.0: 100%|████████████████████████████████████████████████████| 124/124 [00:46<00:00,  2.65 Locale/s]
+================================================================================
+Total           : Ver: 16 LC: 1336 Algo: 5 Splits: 0
+Processed       : Ver: 16 LC: 1336 Algo: 6680
+Skipped         : Exists: 0 No Data: 0
+Duration(s)     : Total: 270.86 Avg: 0.203
+
+
+$ python .\text_corpus_compile.py
+=== cv-tbox-dataset-compiler: Text-Corpora Compilation Process ===
+Preparing directory structures...
+=== HANDLE: v17.0 @ 2024-03-15 ===
+Total: 124 Existing: 0 Remaining: 124 Procs: 12  chunk_size: 1...
+Processing: ['de', 'fr', 'en', 'rw', 'ab', 'ca', 'es', 'bn', 'it', 'gl', 'be', 'tr', 'cs', 'mhr', 'hy-AM', 'hu', 'pl', 'nl', 'ka', 'uk', 'ta', 'eu', 'lg', 'ba', 'eo', 'kab', 'sw', 'uz', 'lt', 'cy', 'az', 'th', 'ru', 'ar', 'mrj', 'fa', 'zh-CN', 'bg', 'hi', 'tw', 'pt', 'ja', 'ug', 'lv', 'sv-SE', 'nan-tw', 'ur', 'da', 'ckb', 'tt', 'pa-IN', 'zh-HK', 'zh-TW', 'kmr', 'ig', 'et', 'ro', 'id', 'mr', 'fy-NL', 'dv', 'or', 'lo', 'ltg', 'sah', 'yue', 'mn', 'rm-sursilv', 'ml', 'hsb', 'ia', 'as', 'lij', 'ko', 'sk', 'el', 'kk', 'myv', 'mk', 'mdf', 'br', 'sat', 'yo', 'sq', 'tok', 'rm-vallader', 'skr', 'tig', 'sr', 'ky', 'fi', 'is', 'he', 'ti', 'cv', 'af', 'vi', 'mt', 'gn', 'sc', 'ha', 'nn-NO', 'dyu', 'oc', 'vot', 'cnh', 'bas', 'zza', 'sl', 'am', 'zgh', 'tk', 'ps', 'nso', 'os', 'ast', 'ne-NP', 'ga-IE', 'zu', 'yi', 'nhi', 'quy', 'te', 'ht']
+Locales: 100%|██████████████████████████████████████████████████████| 124/124 [40:42<00:00, 19.70s/it] 
+=== HANDLE INDEXING: v17.0 @ 2024-03-15 ===
+Total: 124 Existing: 124 Remaining: 0 Procs: 12  chunk_size: 0...
+=== HANDLE INDEXING: v16.1 @ 2023-12-06 ===
+Total: 120 Existing: 0 Remaining: 120 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 120/120 [00:26<00:00,  4.50it/s] 
+=== HANDLE INDEXING: v15.0 @ 2023-09-08 ===
+Total: 114 Existing: 0 Remaining: 114 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 114/114 [00:22<00:00,  5.09it/s] 
+=== HANDLE INDEXING: v14.0 @ 2023-06-23 ===
+Total: 112 Existing: 0 Remaining: 112 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 112/112 [00:22<00:00,  4.89it/s] 
+=== HANDLE INDEXING: v13.0 @ 2023-03-09 ===
+Total: 108 Existing: 0 Remaining: 108 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 108/108 [00:22<00:00,  4.82it/s] 
+=== HANDLE INDEXING: v12.0 @ 2022-12-07 ===
+Total: 104 Existing: 0 Remaining: 104 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 104/104 [00:22<00:00,  4.66it/s] 
+=== HANDLE INDEXING: v11.0 @ 2022-09-21 ===
+Total: 100 Existing: 0 Remaining: 100 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 100/100 [00:22<00:00,  4.42it/s] 
+=== HANDLE INDEXING: v10.0 @ 2022-07-04 ===
+Total: 96 Existing: 0 Remaining: 96 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 96/96 [00:22<00:00,  4.34it/s]
+=== HANDLE INDEXING: v9.0 @ 2022-04-27 ===
+Total: 93 Existing: 0 Remaining: 93 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 93/93 [00:21<00:00,  4.31it/s]
+=== HANDLE INDEXING: v8.0 @ 2022-01-19 ===
+Total: 87 Existing: 0 Remaining: 87 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 87/87 [00:20<00:00,  4.17it/s]
+=== HANDLE INDEXING: v7.0 @ 2021-07-21 ===
+Total: 76 Existing: 0 Remaining: 76 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 76/76 [00:20<00:00,  3.76it/s]
+=== HANDLE INDEXING: v6.1 @ 2020-12-11 ===
+Total: 60 Existing: 0 Remaining: 60 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 60/60 [00:17<00:00,  3.34it/s]
+=== HANDLE INDEXING: v5.1 @ 2020-06-22 ===
+Total: 54 Existing: 0 Remaining: 54 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 54/54 [00:17<00:00,  3.12it/s]
+=== HANDLE INDEXING: v4 @ 2019-12-10 ===
+Total: 40 Existing: 0 Remaining: 40 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 40/40 [00:15<00:00,  2.54it/s]
+=== HANDLE INDEXING: v3 @ 2019-06-24 ===
+Total: 29 Existing: 0 Remaining: 29 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 29/29 [00:12<00:00,  2.26it/s]
+=== HANDLE INDEXING: v1 @ 2019-02-25 ===
+Total: 19 Existing: 0 Remaining: 19 Procs: 12  chunk_size: 1...
+Locales: 100%|██████████████████████████████████████████████████████| 19/19 [00:04<00:00,  3.93it/s]
+================================================================================
+Total           : Ver: 16 LC: 1460 Algo: 5 Splits: 0
+Processed       : Ver: 17 LC: 1336 Algo: 0
+Skipped         : Exists: 124 No Data: 0
+Duration(s)     : Total: 2778.214 Avg: 2.08
+
+
+```
+
+The process took about 03:30 for the whole set. Before the latest changes, in v16.1, the process was taking about 24 hours.
+The results are cached. Thus, when calculating after a new CV release, the code will only calculate the new ones.
+On the other hand, the cached data totals 264 GB uncompressed for v17.0 and prior.
+But, the `.json` files passed to the Common Voice Dataset Analyzer is only 76.6 MB.

--- a/conf.py
+++ b/conf.py
@@ -17,7 +17,7 @@ CV_TBOX_CACHE: str = os.path.join("C:", os.sep, "GITREPO", "_HK_GITHUB", "cv-tbo
 
 # This is where your compressed splits will go (under "upload" and "uploaded") - so that we can upload it to Google Drive
 COMPRESSED_RESULTS_BASE_DIR: str = os.path.join(
-    "C:", os.sep, "GITREPO", "_HK_GITHUB", "cv-tbox-dataset-compiler", "data", "results"
+    "N:", os.sep, "GITREPO", "_HK_GITHUB", "cv-tbox-dataset-compiler", "data", "results"
 )
 
 # Regenerate the data or skip existing?

--- a/conf.py
+++ b/conf.py
@@ -40,5 +40,5 @@ SAVE_LEVEL: int = c.SAVE_LEVEL_DEFAULT
 # Debug & Limiters
 DEBUG: bool = False
 DEBUG_PROC_COUNT: int = 1
-DEBUG_CV_VER: list[str] = ["16.1"]
+DEBUG_CV_VER: list[str] = ["17.0"]
 DEBUG_CV_LC: list[str] = ["tr"]

--- a/conf.py
+++ b/conf.py
@@ -12,7 +12,9 @@ SRC_BASE_DIR: str = os.path.join(
 )
 
 # This is where cache of API calls and clones are kept, common to cv-tbox repors
-CV_TBOX_CACHE: str = os.path.join("C:", os.sep, "GITREPO", "_HK_GITHUB", "cv-tbox-cache")
+CV_TBOX_CACHE: str = os.path.join(
+    "C:", os.sep, "GITREPO", "_HK_GITHUB", "cv-tbox-cache"
+)
 
 
 # This is where your compressed splits will go (under "upload" and "uploaded") - so that we can upload it to Google Drive
@@ -40,5 +42,5 @@ SAVE_LEVEL: int = c.SAVE_LEVEL_DEFAULT
 # Debug & Limiters
 DEBUG: bool = False
 DEBUG_PROC_COUNT: int = 1
-DEBUG_CV_VER: list[str] = ["17.0"]
+DEBUG_CV_VER: list[str] = ["15.0", "16.1", "17.0"]
 DEBUG_CV_LC: list[str] = ["tr"]

--- a/const.py
+++ b/const.py
@@ -80,10 +80,8 @@ EXTENDED_BUCKET_FILES: list[str] = [
 TRAINING_SPLITS: list[str] = ["train", "dev", "test"]
 SPLIT_FILES: list[str] = ["train.tsv", "dev.tsv", "test.tsv"]
 
-TC_BUCKETS: list[str] = ["validated_sentences", "unvalidated_sentences"]
-TC_BUCKET_FILES: list[str] = ["validated_sentences.tsv", "unvalidated_sentences.tsv"]
-
 NODATA: str = "nodata"  # .isna cases replaced with this
+
 CV_GENDERS: list[str] = ["male", "female", "other", NODATA]
 # new gender definitions
 CV_GENDERS_EXTENDED: list[str] = [
@@ -104,6 +102,7 @@ CV_GENDERS_MAPPING: dict = {
     "non-binary": "other",
     "do_not_wish_to_say": "other",
 }
+
 CV_AGES: list[str] = [
     "teens",
     "twenties",
@@ -117,39 +116,35 @@ CV_AGES: list[str] = [
     NODATA,
 ]
 
-# COLUMNS FOR DATAFRAMES
+# Domains
+CV_DOMAINS: list[str] = [
+    "general",
+    "agriculture",
+    "automotive",
+    "finance",
+    "food_service_retail",
+    "healthcare",
+    "history_law_government",
+    "media_entertainment",
+    "nature_environment",
+    "news_current_affairs",
+    "technology_robotics",
+    "language_fundamentals",
+]
+
+# CLIP DURATIONS
 CLIP_DURATIONS_FILE: str = "clip_durations.tsv"
 COLS_CLIP_DURATIONS: list[str] = [
     "clip",
     "duration[ms]",
 ]
 
-
 #
-# cv-tbox related
+# TEXT-CORPUS RELATED
 #
-
-ALGORITHMS: list[str] = ["s1", "s99", "v1", "vw", "vx"]
-
-# SEPARATORS
-SEP_ROW: str = "|"
-SEP_COL: str = "#"
-SEP_ALGO: str = "|"
-
-#
-# COLUMNS FOR DATAFRAMES
-#
-
-# COLS_SPLIT_STATS: list[str] = [
-#     'file',
-#     'sentence',
-#     'chars',
-# ]
-
-
-#
-# COLUMNS FOR TEXT-CORPUS RELATED
-#
+TC_BUCKETS: list[str] = ["validated_sentences", "unvalidated_sentences"]
+TC_BUCKET_FILES: list[str] = ["validated_sentences.tsv", "unvalidated_sentences.tsv"]
+TC_VALIDATED_FILE: str = TC_BUCKET_FILES[0]
 
 COLS_TC_UNVALIDATED: list[str] = [
     "sentence_id",
@@ -168,8 +163,18 @@ COLS_TC_VALIDATED: list[str] = [
 ]
 
 COLS_TEXT_CORPUS: list[str] = [
-    "file",
+    "sentence_id",
     "sentence",
+    "sentence_domain",
+    "source",
+    "is_used",
+    "clips_count",
+    "normalized",  # normalized sentence
+    "phonemised",  # phonemised sentence
+    "tokens",  # list of tokens
+    "char_cnt",  # number of characters (graphemes)
+    "word_cnt",  # number of words
+    "valid",  # is it a valid sentence according to commonvoice-utils? 1=valid
 ]
 
 COLS_TC_STATS: list[str] = [
@@ -235,6 +240,16 @@ REPORTING_BASE: list[str] = [
 REPORTING_ALL: list[str] = REPORTING_BASE.copy()
 REPORTING_ALL.append("other")
 
+#
+# cv-tbox related
+#
+
+ALGORITHMS: list[str] = ["s1", "s99", "v1", "vw", "vx"]
+
+# SEPARATORS
+SEP_ROW: str = "|"
+SEP_COL: str = "#"
+SEP_ALGO: str = "|"
 
 #
 # DIRECTORIES / FILENAMES
@@ -243,6 +258,7 @@ DATA_DIRNAME: str = "data"
 RES_DIRNAME: str = "results"
 
 TC_DIRNAME: str = "text-corpus"
+TC_ANALYSIS_DIRNAME: str = "text-analysis"
 VC_DIRNAME: str = "voice-corpus"
 CD_DIRNAME: str = "clip-durations"
 UPLOAD_DIRNAME: str = "upload"

--- a/const.py
+++ b/const.py
@@ -1,4 +1,5 @@
 """Constants for cv-tbox Dataset Compiler"""
+
 ###########################################################################
 # const.py
 #
@@ -40,7 +41,7 @@ CV_VERSIONS: list[str] = [
     "14.0",
     "15.0",
     "16.1",
-    # "17.0",
+    "17.0",
     # "18.0",
     # "19.0",
     # "20.0",
@@ -62,7 +63,7 @@ CV_DATES: list[str] = [
     "2023-06-23",
     "2023-09-08",
     "2023-12-06",
-    # "2024-03-00",
+    "2024-03-15",
     # "2024-06-00",
     # "2024-09-00",
     # "2024-12-00",
@@ -80,6 +81,25 @@ SPLIT_FILES: list[str] = ["train.tsv", "dev.tsv", "test.tsv"]
 
 NODATA: str = "nodata"  # .isna cases replaced with this
 CV_GENDERS: list[str] = ["male", "female", "other", NODATA]
+# new gender definitions
+CV_GENDERS_EXTENDED: list[str] = [
+    "male_masculine",
+    "female_feminine",
+    "intersex",
+    "transgender",
+    "non-binary",
+    "do_not_wish_to_say",
+    NODATA,
+]
+# backmapping of new genders for backwards compatibility
+CV_GENDERS_MAPPING: dict = {
+    "male_masculine": "male",
+    "female_feminine": "female",
+    "intersex": "other",
+    "transgender": "other",
+    "non-binary": "other",
+    "do_not_wish_to_say": "other",
+}
 CV_AGES: list[str] = [
     "teens",
     "twenties",
@@ -236,7 +256,26 @@ SAVE_LEVEL_DETAILED = 2  # save every calculated result for all algorithms
 # BINS
 #
 
-BINS_DURATION: list[int] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 999999]
+BINS_DURATION: list[int] = [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    20,
+    999999,
+]
 BINS_VOICES: list[int] = [
     0,
     1,
@@ -294,6 +333,11 @@ BINS_CHARS: list[int] = [
     130,
     140,
     150,
+    160,
+    170,
+    180,
+    190,
+    200,
     999999,
 ]
 BINS_WORDS: list[int] = [
@@ -318,6 +362,11 @@ BINS_WORDS: list[int] = [
     18,
     19,
     20,
+    21,
+    22,
+    23,
+    24,
+    25,
     999999,
 ]
 BINS_TOKENS: list[int] = [

--- a/const.py
+++ b/const.py
@@ -12,7 +12,35 @@
 # Copyright: (c) Bülent Özden, License: AGPL v3.0
 ###########################################################################
 
-from typedef import GitRec
+# Standard Lib
+
+# External dependencies
+import pandas as pd
+
+# Module
+from typedef import (
+    GitRec,
+    dtype_pa_uint8,
+    dtype_pa_uint16,
+    dtype_pa_uint32,
+    dtype_pa_uint64,
+    # dtype_pa_float16,
+    dtype_pa_float32,
+    # dtype_pa_float64,
+    dtype_pa_str,
+    dtype_pa_list_str,
+    # dtype_pa_list_uint8,
+    # dtype_pa_list_uint16,
+    # dtype_pa_list_uint32,
+    dtype_pa_list_uint64,
+)
+
+
+#
+# Pandans 2 settings
+#
+pd.options.mode.copy_on_write = True
+
 
 #
 # cv related
@@ -134,10 +162,10 @@ CV_DOMAINS: list[str] = [
 
 # CLIP DURATIONS
 CLIP_DURATIONS_FILE: str = "clip_durations.tsv"
-COLS_CLIP_DURATIONS: list[str] = [
-    "clip",
-    "duration[ms]",
-]
+FIELDS_CLIP_DURATIONS: dict[str, pd.ArrowDtype] = {
+    "clip": dtype_pa_str,
+    "duration[ms]": dtype_pa_uint32,
+}
 
 #
 # TEXT-CORPUS RELATED
@@ -146,89 +174,96 @@ TC_BUCKETS: list[str] = ["validated_sentences", "unvalidated_sentences"]
 TC_BUCKET_FILES: list[str] = ["validated_sentences.tsv", "unvalidated_sentences.tsv"]
 TC_VALIDATED_FILE: str = TC_BUCKET_FILES[0]
 
-COLS_TC_UNVALIDATED: list[str] = [
-    "sentence_id",
-    "sentence",
-    "sentence_domain",
-    "source",
-]
+FIELDS_TC_UNVALIDATED: dict[str, pd.ArrowDtype] = {
+    "sentence_id": dtype_pa_str,
+    "sentence": dtype_pa_str,
+    "sentence_domain": dtype_pa_str,
+    "source": dtype_pa_str,
+}
 
-COLS_TC_VALIDATED: list[str] = [
-    "sentence_id",
-    "sentence",
-    "sentence_domain",
-    "source",
-    "is_used",
-    "clips_count",
-]
+FIELDS_TC_VALIDATED: dict[str, pd.ArrowDtype] = {
+    "sentence_id": dtype_pa_str,
+    "sentence": dtype_pa_str,
+    "sentence_domain": dtype_pa_str,
+    "source": dtype_pa_str,
+    "is_used": dtype_pa_uint8,
+    "clips_count": dtype_pa_uint16,
+}
 
-COLS_TEXT_CORPUS: list[str] = [
-    "sentence_id",
-    "sentence",
-    "sentence_domain",
-    "source",
-    "is_used",
-    "clips_count",
-    "normalized",  # normalized sentence
-    "phonemised",  # phonemised sentence
-    "tokens",  # list of tokens
-    "char_cnt",  # number of characters (graphemes)
-    "word_cnt",  # number of words
-    "valid",  # is it a valid sentence according to commonvoice-utils? 1=valid
-]
+FIELDS_TEXT_CORPUS: dict[str, pd.ArrowDtype] = {
+    "sentence_id": dtype_pa_str,
+    "sentence": dtype_pa_str,
+    "sentence_domain": dtype_pa_str,
+    "source": dtype_pa_str,
+    "is_used": dtype_pa_uint8,
+    "clips_count": dtype_pa_uint8,
+    "normalized": dtype_pa_str,
+    "phonemised": dtype_pa_str,
+    "tokens": dtype_pa_list_str,
+    "char_cnt": dtype_pa_uint16,
+    "word_cnt": dtype_pa_uint8,
+    "valid": dtype_pa_uint8,
+}
 
-COLS_TC_STATS: list[str] = [
-    "ver",
-    "lc",
-    "algo",
-    "sp",
-    "has_val",
-    "has_phon",
-    "s_cnt",
-    "uq_s",
-    "uq_n",
-    "val",
-    "c_sum",
-    "c_avg",
-    "c_med",
-    "c_std",
-    "c_freq",
-    "w_sum",
-    "w_avg",
-    "w_med",
-    "w_std",
-    "w_freq",
-    "t_sum",
-    "t_avg",
-    "t_med",
-    "t_std",
-    "t_freq",
-    "g_cnt",
-    "g_freq",
-    "p_cnt",
-    "p_freq",
-]
+FIELDS_TC_STATS: dict[str, pd.ArrowDtype] = {
+    "ver": dtype_pa_str,
+    "lc": dtype_pa_str,
+    "algo": dtype_pa_str,
+    "sp": dtype_pa_str,
+    "has_val": dtype_pa_uint8,
+    "has_phon": dtype_pa_uint8,
+    "s_cnt": dtype_pa_uint32,
+    "uq_s": dtype_pa_uint32,
+    "uq_n": dtype_pa_uint32,
+    "val": dtype_pa_uint8,
+    "c_sum": dtype_pa_uint32,
+    "c_avg": dtype_pa_float32,
+    "c_med": dtype_pa_float32,
+    "c_std": dtype_pa_float32,
+    "c_freq": dtype_pa_list_uint64,
+    "w_sum": dtype_pa_uint32,
+    "w_avg": dtype_pa_float32,
+    "w_med": dtype_pa_float32,
+    "w_std": dtype_pa_float32,
+    "w_freq": dtype_pa_list_uint64,
+    "t_sum": dtype_pa_uint32,
+    "t_avg": dtype_pa_float32,
+    "t_med": dtype_pa_float32,
+    "t_std": dtype_pa_float32,
+    "t_freq": dtype_pa_list_uint64,
+    "g_cnt": dtype_pa_uint16,
+    "g_freq": dtype_pa_list_uint64,
+    "p_cnt": dtype_pa_uint16,
+    "p_freq": dtype_pa_list_uint64,
+}
 
-COLS_TOKENS: list[str] = ["token", "count"]
-COLS_GRAPHEMES: list[str] = ["grapheme", "count"]
-COLS_PHONEMES: list[str] = ["phoneme", "count"]
-
+FIELDS_TOKENS: dict[str, pd.ArrowDtype] = {
+    "token": dtype_pa_str,
+    "count": dtype_pa_uint64,
+}
+FIELDS_GRAPHEMES: dict[str, pd.ArrowDtype] = {
+    "grapheme": dtype_pa_str,
+    "count": dtype_pa_uint64,
+}
+FIELDS_PHONEMES: dict[str, pd.ArrowDtype] = {
+    "phoneme": dtype_pa_str,
+    "count": dtype_pa_uint64,
+}
 
 #
 # REPORTED SENTENCES
 #
-COLS_REPORTED_STATS: list[str] = [
-    "ver",
-    "lc",
-    "rep_sum",
-    "rep_sen",
-    "rep_avg",
-    "rep_med",
-    "rep_std",
-    "rep_freq",
-    "rea_freq",
-]
-
+FIELDS_REPORTED_STATS: dict[str, pd.ArrowDtype] = {
+    "ver": dtype_pa_str,
+    "lc": dtype_pa_str,
+    "rep_sum": dtype_pa_uint32,
+    "rep_sen": dtype_pa_uint32,
+    "rep_avg": dtype_pa_float32,
+    "rep_med": dtype_pa_float32,
+    "rep_std": dtype_pa_float32,
+    "rep_freq": dtype_pa_list_uint64,
+    "rea_freq": dtype_pa_list_uint64,
+}
 
 REPORTING_BASE: list[str] = [
     "offensive-language",

--- a/const.py
+++ b/const.py
@@ -110,6 +110,23 @@ SPLIT_FILES: list[str] = ["train.tsv", "dev.tsv", "test.tsv"]
 
 NODATA: str = "nodata"  # .isna cases replaced with this
 
+FIELDS_BUCKETS_SPLITS: dict[str, pd.ArrowDtype] = {
+    "client_id": dtype_pa_str,
+    "path": dtype_pa_str,
+    "sentence_id": dtype_pa_str,
+    "sentence": dtype_pa_str,
+    "sentence_domain": dtype_pa_str,
+    "up_votes": dtype_pa_uint16,
+    "down_votes": dtype_pa_uint16,
+    "age": dtype_pa_str,
+    "gender": dtype_pa_str,
+    "accents": dtype_pa_str,
+    "variant": dtype_pa_str,
+    "locale": dtype_pa_str,
+    "segment": dtype_pa_str,
+}
+
+
 CV_GENDERS: list[str] = ["male", "female", "other", NODATA]
 # new gender definitions
 CV_GENDERS_EXTENDED: list[str] = [

--- a/const.py
+++ b/const.py
@@ -76,8 +76,12 @@ EXTENDED_BUCKET_FILES: list[str] = [
     "other.tsv",
     "reported.tsv",
 ]
+
 TRAINING_SPLITS: list[str] = ["train", "dev", "test"]
 SPLIT_FILES: list[str] = ["train.tsv", "dev.tsv", "test.tsv"]
+
+TC_BUCKETS: list[str] = ["validated_sentences", "unvalidated_sentences"]
+TC_BUCKET_FILES: list[str] = ["validated_sentences.tsv", "unvalidated_sentences.tsv"]
 
 NODATA: str = "nodata"  # .isna cases replaced with this
 CV_GENDERS: list[str] = ["male", "female", "other", NODATA]
@@ -147,6 +151,21 @@ SEP_ALGO: str = "|"
 # COLUMNS FOR TEXT-CORPUS RELATED
 #
 
+COLS_TC_UNVALIDATED: list[str] = [
+    "sentence_id",
+    "sentence",
+    "sentence_domain",
+    "source",
+]
+
+COLS_TC_VALIDATED: list[str] = [
+    "sentence_id",
+    "sentence",
+    "sentence_domain",
+    "source",
+    "is_used",
+    "clips_count",
+]
 
 COLS_TEXT_CORPUS: list[str] = [
     "file",

--- a/const.py
+++ b/const.py
@@ -232,9 +232,14 @@ FIELDS_TC_STATS: dict[str, pd.ArrowDtype] = {
     "t_std": dtype_pa_float32,
     "t_freq": dtype_pa_list_uint64,
     "g_cnt": dtype_pa_uint16,
+    "g_items": dtype_pa_str,  # dtype_pa_list_str,
     "g_freq": dtype_pa_list_uint64,
     "p_cnt": dtype_pa_uint16,
+    "p_items": dtype_pa_str,  # dtype_pa_list_str,
     "p_freq": dtype_pa_list_uint64,
+    "dom_cnt": dtype_pa_uint16,
+    "dom_items": dtype_pa_list_str,
+    "dom_freq": dtype_pa_list_uint64,
 }
 
 FIELDS_TOKENS: dict[str, pd.ArrowDtype] = {
@@ -247,6 +252,10 @@ FIELDS_GRAPHEMES: dict[str, pd.ArrowDtype] = {
 }
 FIELDS_PHONEMES: dict[str, pd.ArrowDtype] = {
     "phoneme": dtype_pa_str,
+    "count": dtype_pa_uint64,
+}
+FIELDS_SENTENCE_DOMAINS: dict[str, pd.ArrowDtype] = {
+    "sentence_domain": dtype_pa_str,
     "count": dtype_pa_uint64,
 }
 
@@ -305,6 +314,7 @@ TEXT_CORPUS_FN: str = "$text_corpus"
 TOKENS_FN: str = "$tokens"
 GRAPHEMES_FN: str = "$graphemes"
 PHONEMES_FN: str = "$phonemes"
+DOMAINS_FN: str = "$domains"
 
 TEXT_CORPUS_STATS_FN: str = "tc_stats"
 REPORTED_STATS_FN: str = "$reported"

--- a/final_compile.py
+++ b/final_compile.py
@@ -43,6 +43,7 @@ from typedef import (
 from lib import (
     df_read,
     df_write,
+    gender_backmapping,
     init_directories,
     # list2str,
     # arr2str,
@@ -556,6 +557,8 @@ def handle_dataset_splits(ds_path: str) -> list[SplitStatsRec]:
 
         # Replace NA with NODATA
         df: pd.DataFrame = df_orig.fillna(value=c.NODATA)
+        # backmap genders
+        df = gender_backmapping(df)
         # add lowercase sentence column
         df["sentence_lower"] = df["sentence"].str.lower()
 

--- a/final_compile.py
+++ b/final_compile.py
@@ -16,12 +16,13 @@
 ###########################################################################
 
 # Standard Lib
+from collections import Counter
+from datetime import datetime
+from ast import literal_eval
 import os
 import sys
 import glob
 import multiprocessing as mp
-from collections import Counter
-from datetime import datetime
 
 # External dependencies
 from tqdm import tqdm
@@ -39,18 +40,19 @@ from typedef import (
     TextCorpusStatsRec,
     ReportedStatsRec,
     SplitStatsRec,
+    dtype_pa_str,
 )
 from lib import (
     df_read,
     df_write,
     gender_backmapping,
     init_directories,
-    # list2str,
-    # arr2str,
     dec3,
     calc_dataset_prefix,
     get_locales_from_cv_dataset,
+    list2str,
     report_results,
+    sort_by_largest_file,
 )
 
 # Globals
@@ -61,7 +63,7 @@ if not HERE in sys.path:
 
 # PROC_COUNT: int = psutil.cpu_count(logical=False) - 1     # Limited usage
 PROC_COUNT: int = psutil.cpu_count(logical=True)  # Full usage
-MAX_BATCH_SIZE: int = 5
+MAX_BATCH_SIZE: int = 1
 
 ALL_LOCALES: list[str] = get_locales_from_cv_dataset(c.CV_VERSIONS[-1])
 
@@ -90,22 +92,6 @@ g_vc: Globals = Globals(
 def handle_text_corpus(ver_lc: str) -> list[TextCorpusStatsRec]:
     """Multi-Process text-corpus for a single locale"""
 
-    ver: str = ver_lc.split("|")[0]
-    lc: str = ver_lc.split("|")[1]
-    ver_dir: str = calc_dataset_prefix(ver)
-
-    tc_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME, ver_dir, lc)
-    tc_file: str = os.path.join(tc_dir, f"{c.TEXT_CORPUS_FN}.tsv")
-
-    # cvu - do we have them?
-    validator: cvu.Validator | None = cvu.Validator(lc) if lc in VALIDATORS else None
-    phonemiser: cvu.Phonemiser | None = (
-        cvu.Phonemiser(lc) if lc in PHONEMISERS else None
-    )
-    tokeniser: cvu.Tokeniser = cvu.Tokeniser(lc)
-
-    results: list[TextCorpusStatsRec] = []
-
     def handle_df(
         df: pd.DataFrame, algo: str = "", sp: str = ""
     ) -> TextCorpusStatsRec | None:
@@ -113,7 +99,9 @@ def handle_text_corpus(ver_lc: str) -> list[TextCorpusStatsRec]:
 
         if df.shape[0] == 0:
             if conf.VERBOSE:
-                print(f"WARN: Skipping empty data for: {ver} - {lc} - {algo} - {sp}")
+                print(
+                    f"WARN: Skipping empty data for: Ver: {ver} - LC: {lc} - Algo: {algo} - Split: {sp}"
+                )
             return None
 
         # prep result record with default
@@ -122,8 +110,8 @@ def handle_text_corpus(ver_lc: str) -> list[TextCorpusStatsRec]:
             lc=lc,
             algo=algo,
             sp=sp,
-            has_val=lc in VALIDATORS,
-            has_phon=lc in PHONEMISERS,
+            has_val=has_validator,
+            has_phon=has_phonemiser,
         )
 
         # init counters
@@ -148,74 +136,48 @@ def handle_text_corpus(ver_lc: str) -> list[TextCorpusStatsRec]:
         _ser: pd.Series[int] = pd.Series()  # pylint: disable=unsubscriptable-object
         _df2: pd.DataFrame = pd.DataFrame()
 
-        # add columns
-        _df: pd.DataFrame = (
-            df.reindex(
-                columns=[
-                    "sentence",
-                    "normalized",  # normalized sentence
-                    "phonemised",  # phonemised sentence
-                    "tokens",  # list of tokens
-                    "char_cnt",  # number of characters (graphemes)
-                    "word_cnt",  # number of words
-                    "valid",  # is it a valid sentence according to commonvoice-utils? 1=valid
-                ]
-            )
-            .copy()
-            .reset_index(drop=True)
-        )
-
-        # pre-calc simpler values
-        _df["char_cnt"] = [
-            len(s) if isinstance(s, str) else 0 for s in _df["sentence"].to_list()
-        ]
-
         # validator dependent
-        if validator:
-            _df["normalized"] = [
-                validator.validate(s) if isinstance(s, str) else None
-                for s in _df["sentence"].tolist()
-            ]
-            _df["valid"] = [0 if n is None else 1 for n in _df["normalized"].tolist()]
-            _df["tokens"] = [
-                None if s is None else tokeniser.tokenise(s)
-                for s in _df["normalized"].tolist()
-            ]
-            _df["word_cnt"] = [
-                None if ww is None else len(ww) for ww in _df["tokens"].tolist()
-            ]
-            _ = [token_counter.update(ww) for ww in _df["tokens"].dropna().tolist()]
+        if has_validator:
+            token_counter.update(
+                w
+                for ww in df["tokens"].dropna().apply(literal_eval).to_list()
+                for w in ww
+            )
 
             # word_cnt stats
-            _ser = _df["word_cnt"].dropna()
-            res.w_sum = _ser.sum()
-            res.w_avg = dec3(_ser.mean())
-            res.w_med = _ser.median()
-            res.w_std = dec3(_ser.std(ddof=0))
-            # Calc word count distribution
-            _arr: np.ndarray = np.fromiter(
-                _ser.apply(int).reset_index(drop=True).to_list(), int
-            )
-            _hist = np.histogram(_arr, bins=c.BINS_WORDS)
-            res.w_freq = _hist[0].tolist()
+            _ser = df["word_cnt"].dropna()
+            if _ser.shape[0] > 0:
+                res.w_sum = _ser.sum()
+                res.w_avg = dec3(_ser.mean())
+                res.w_med = _ser.median()
+                res.w_std = dec3(_ser.std(ddof=0))
+                # Calc word count distribution
+                _arr: np.ndarray = np.fromiter(
+                    _ser.apply(int).reset_index(drop=True).to_list(), int
+                )
+                _hist = np.histogram(_arr, bins=c.BINS_WORDS)
+                res.w_freq = _hist[0].tolist()
 
             # token_cnt stats
-            _df2 = pd.DataFrame(token_counter.most_common(), columns=c.COLS_TOKENS)
+            _df2 = pd.DataFrame(token_counter.most_common(), columns=c.FIELDS_TOKENS)
+
             # "token", "count"
             res.t_sum = _df2.shape[0]
             _ser = _df2["count"].dropna()
-            res.t_avg = dec3(_ser.mean())
-            res.t_med = _ser.median()
-            res.t_std = dec3(_ser.std(ddof=0))
-            # Token/word repeat distribution
-            _arr: np.ndarray = np.fromiter(
-                _df2["count"].dropna().apply(int).reset_index(drop=True).to_list(), int
-            )
-            _hist = np.histogram(_arr, bins=c.BINS_TOKENS)
-            res.t_freq = _hist[0].tolist()
+            if _ser.shape[0] > 0:
+                res.t_avg = dec3(_ser.mean())
+                res.t_med = _ser.median()
+                res.t_std = dec3(_ser.std(ddof=0))
+                # Token/word repeat distribution
+                _arr: np.ndarray = np.fromiter(
+                    _df2["count"].dropna().apply(int).reset_index(drop=True).to_list(),
+                    int,
+                )
+                _hist = np.histogram(_arr, bins=c.BINS_TOKENS)
+                res.t_freq = _hist[0].tolist()
             if do_save:
                 fn: str = os.path.join(
-                    tc_dir,
+                    tc_anal_dir,
                     f"{c.TOKENS_FN}_{algo}_{sp}.tsv".replace("__", "_").replace(
                         "_.", "."
                     ),
@@ -223,23 +185,20 @@ def handle_text_corpus(ver_lc: str) -> list[TextCorpusStatsRec]:
                 df_write(_df2, fn)
 
         # phonemiser dependent
-        if phonemiser:
-            _df["phonemised"] = [
-                phonemiser.phonemise(s) if isinstance(s, str) else None
-                for s in _df["sentence"].tolist()
-                # for w in str(s).split(" ")
-            ]
-            _ = [phoneme_counter.update(p) for p in _df["phonemised"].dropna().tolist()]
+        if has_phonemiser:
+            _ = [phoneme_counter.update(p) for p in df["phonemised"].dropna().tolist()]
 
             # PHONEMES
-            _df2 = pd.DataFrame(phoneme_counter.most_common(), columns=c.COLS_PHONEMES)
+            _df2 = pd.DataFrame(
+                phoneme_counter.most_common(), columns=c.FIELDS_PHONEMES
+            )
             _values = _df2.values.tolist()
             res.p_cnt = len(_values)
-            # res.p_freq = arr2str(_values)
-            res.p_freq = _values
+            res.p_items = list2str([x[0] for x in _values])
+            res.p_freq = [x[1] for x in _values]
             if do_save:
                 fn: str = os.path.join(
-                    tc_dir,
+                    tc_anal_dir,
                     f"{c.PHONEMES_FN}_{algo}_{sp}.tsv".replace("__", "_").replace(
                         "_.", "."
                     ),
@@ -247,76 +206,171 @@ def handle_text_corpus(ver_lc: str) -> list[TextCorpusStatsRec]:
                 df_write(_df2, fn)
 
         # simpler values which are independent
-        res.s_cnt = _df.shape[0]
-        res.val = _df["valid"].dropna().astype(int).sum()
-        res.uq_s = _df["sentence"].dropna().unique().shape[0]
-        res.uq_n = _df["normalized"].dropna().unique().shape[0]
+        res.s_cnt = df.shape[0]
+        res.val = df["valid"].dropna().astype(int).sum()
+        res.uq_s = df["sentence"].dropna().unique().shape[0]
+        res.uq_n = df["normalized"].dropna().unique().shape[0]
 
         # char_cnt stats
-        _ser = _df["char_cnt"].dropna()
-        res.c_sum = _ser.sum()
-        res.c_avg = dec3(_ser.mean())
-        res.c_med = _ser.median()
-        res.c_std = dec3(_ser.std(ddof=0))
-        # Calc character length distribution
-        _arr: np.ndarray = np.fromiter(
-            _ser.apply(int).reset_index(drop=True).to_list(), int
-        )
-        _hist = np.histogram(_arr, bins=c.BINS_CHARS)
-        res.c_freq = _hist[0].tolist()
+        _ser = df["char_cnt"].dropna()
+        if _ser.shape[0] > 0:
+            res.c_sum = _ser.sum()
+            res.c_avg = dec3(_ser.mean())
+            res.c_med = _ser.median()
+            res.c_std = dec3(_ser.std(ddof=0))
+            # Calc character length distribution
+            _arr: np.ndarray = np.fromiter(
+                _ser.apply(int).reset_index(drop=True).to_list(), int
+            )
+            _hist = np.histogram(_arr, bins=c.BINS_CHARS)
+            res.c_freq = _hist[0].tolist()
 
         # GRAPHEMES
-        _ = [grapheme_counter.update(s) for s in _df["sentence"].dropna().tolist()]
-        _df2 = pd.DataFrame(grapheme_counter.most_common(), columns=c.COLS_GRAPHEMES)
+        _ = [grapheme_counter.update(s) for s in df["sentence"].dropna().tolist()]
+        _df2 = pd.DataFrame(grapheme_counter.most_common(), columns=c.FIELDS_GRAPHEMES)
         _values = _df2.values.tolist()
         res.g_cnt = len(_values)
-        res.g_freq = _df2.values.tolist()
+        res.g_items = list2str([x[0] for x in _values])
+        res.g_freq = [x[1] for x in _values]
         if do_save:
             fn: str = os.path.join(
-                tc_dir,
+                tc_anal_dir,
                 f"{c.GRAPHEMES_FN}_{algo}_{sp}.tsv".replace("__", "_").replace(
                     "_.", "."
                 ),
             )
             df_write(_df2, fn)
+
+        # Domains (for < CV v17.0, they will be "nodata", after that new items are added)
+        _df2 = (
+            df["sentence_domain"]
+            .astype(dtype_pa_str)
+            .fillna(c.NODATA)
+            .value_counts()
+            .to_frame()
+            .reset_index()
+            .reindex(columns=c.FIELDS_SENTENCE_DOMAINS)
+            .sort_values("count", ascending=False)
+        )
+        res.dom_cnt = _df2.shape[0]
+        res.dom_items = _df2["sentence_domain"].to_list()
+        res.dom_freq = _df2["count"].to_list()
+        if do_save:
+            fn: str = os.path.join(
+                tc_anal_dir,
+                f"{c.DOMAINS_FN}_{algo}_{sp}.tsv".replace("__", "_").replace("_.", "."),
+            )
+            df_write(_df2, fn)
+
         # return result
         return res
 
-    def handle_tc_global() -> None:
+    def handle_tc_global(df_base_ver_tc: pd.DataFrame) -> None:
         """Calculate stats using the whole text corpus from server/data"""
-        if not os.path.isfile(tc_file):
-            if conf.VERBOSE:
-                print(f"WARN: No text-corpus file for: {ver} - {lc}")
-            return
-        res: TextCorpusStatsRec | None = handle_df(
-            df_read(tc_file).reset_index(drop=True)[["sentence"]]
-        )
-        if res is not None:
-            results.append(res)
+        # res: TextCorpusStatsRec | None = handle_df(
+        #     df_read(base_tc_file).reset_index(drop=True)[["sentence"]]
+        # )
+        _res: TextCorpusStatsRec | None = handle_df(df_base_ver_tc)
+        if _res is not None:
+            results.append(_res)
 
-    def handle_tc_split(sp: str, algo: str = "") -> None:
-        """Calculate stats using sentence data in a bucket/split"""
-        fn: str = os.path.join(conf.SRC_BASE_DIR, algo, ver_dir, lc, f"{sp}.tsv")
-        if not os.path.isfile(fn):
+    def handle_tc_split(df_base_ver_tc: pd.DataFrame, sp: str, algo: str = "") -> None:
+        """Calculate stats using sentence data in a algo - bucket/split"""
+        _fn: str = os.path.join(conf.SRC_BASE_DIR, algo, ver_dir, lc, f"{sp}.tsv")
+        if not os.path.isfile(_fn):
             if conf.VERBOSE:
                 print(f"WARN: No such split file for: {ver} - {lc} - {algo} - {sp}")
             return
-        res: TextCorpusStatsRec | None = handle_df(
-            df_read(fn).reset_index(drop=True)[["sentence"]], algo=algo, sp=sp
-        )
-        if res is not None:
-            results.append(res)
+        _res: TextCorpusStatsRec | None = None
+        if float(ver) >= 17.0:
+            # For newer versions, just use the sentence_id
+            sentence_id_list: list[str] = (
+                df_read(_fn)
+                .reset_index(drop=True)["sentence_id"]
+                .dropna()
+                .drop_duplicates()
+                .to_list()
+            )
+            df: pd.DataFrame = df_base_ver_tc[
+                df_base_ver_tc["sentence_id"].isin(sentence_id_list)
+            ]
+            _res: TextCorpusStatsRec | None = handle_df(df, algo=algo, sp=sp)
+        else:
+            # For older versions, use the sentence
+            sentence_list: list[str] = (
+                df_read(_fn)
+                .reset_index(drop=True)["sentence"]
+                .dropna()
+                .drop_duplicates()
+                .to_list()
+            )
+            df: pd.DataFrame = df_base_ver_tc[
+                df_base_ver_tc["sentence"].isin(sentence_list)
+            ]
+            _res: TextCorpusStatsRec | None = handle_df(df, algo=algo, sp=sp)
+        if _res is not None:
+            results.append(_res)
 
-    # main
-    handle_tc_global()
+    #
+    # handle_df main
+    #
+    ver: str = ver_lc.split("|")[0]
+    lc: str = ver_lc.split("|")[1]
+    ver_dir: str = calc_dataset_prefix(ver)
+
+    results: list[TextCorpusStatsRec] = []
+
+    base_tc_file: str = os.path.join(
+        HERE, c.DATA_DIRNAME, c.TC_DIRNAME, lc, f"{c.TEXT_CORPUS_FN}.tsv"
+    )
+    ver_tc_inx_file: str = os.path.join(
+        HERE, c.DATA_DIRNAME, c.TC_DIRNAME, lc, f"{c.TEXT_CORPUS_FN}_{ver}.tsv"
+    )
+    if not os.path.isfile(base_tc_file):
+        if conf.VERBOSE:
+            print(f"WARN: No text-corpus file for: {lc}")
+        return results
+    if not os.path.isfile(ver_tc_inx_file):
+        if conf.VERBOSE:
+            print(f"WARN: No text-corpus index file for: {ver} - {lc}")
+        return results
+
+    tc_anal_dir: str = os.path.join(
+        HERE, c.DATA_DIRNAME, c.TC_ANALYSIS_DIRNAME, ver_dir, lc
+    )
+    os.makedirs(tc_anal_dir, exist_ok=True)
+
+    # cvu - do we have them?
+    has_validator: bool = lc in VALIDATORS
+    has_phonemiser: bool = lc in PHONEMISERS
+    # tokeniser: cvu.Tokeniser = cvu.Tokeniser(lc)
+
+    # get and filter text_corpus data
+    df_base_ver_tc: pd.DataFrame = df_read(base_tc_file)
+    # we only should use allowed ones
+    df_base_ver_tc = df_base_ver_tc[df_base_ver_tc["is_used"] == 1]
+    df_ver_inx: pd.DataFrame = df_read(ver_tc_inx_file)
+    sentence_id_list: list[str] = df_ver_inx["sentence_id"].to_list()
+    df_base_ver_tc = df_base_ver_tc[
+        df_base_ver_tc["sentence_id"].isin(sentence_id_list)
+    ]
+    del df_ver_inx
+    df_ver_inx = pd.DataFrame()
+
+    handle_tc_global(df_base_ver_tc)
     for sp in ["validated", "invalidated", "other"]:
-        handle_tc_split(sp, c.ALGORITHMS[0])
+        handle_tc_split(df_base_ver_tc, sp, c.ALGORITHMS[0])
 
     for algo in c.ALGORITHMS:
         for sp in ["train", "dev", "test"]:
-            handle_tc_split(sp, algo)
+            handle_tc_split(df_base_ver_tc, sp, algo)
     # done
     return results
+
+
+# END handle_text_corpus
+
+# END - Text-Corpus Stats (Multi Processing Handler)
 
 
 ########################################################
@@ -392,6 +446,9 @@ def handle_reported(ver_lc: str) -> ReportedStatsRec:
         rea_freq=reason_freq,
     )
     return res
+
+
+# END - Reported Stats
 
 
 ########################################################
@@ -536,17 +593,21 @@ def handle_dataset_splits(ds_path: str) -> list[SplitStatsRec]:
         if split != "clips":
             df_orig: pd.DataFrame = df_read(fpath)
         else:  # build "clips" from val+inval+other
-            df_orig: pd.DataFrame = df_read(
-                fpath
-            )  # we passed validated here, first read it.
-            df2: pd.DataFrame = df_read(
-                fpath.replace("validated", "invalidated")
-            )  # add invalidated
-            df_orig = pd.concat([df_orig.loc[:], df2])
-            df2: pd.DataFrame = df_read(
-                fpath.replace("validated", "other")
-            )  # add other
-            df_orig = pd.concat([df_orig.loc[:], df2])
+            # we passed validated here, first read it.
+            df_orig: pd.DataFrame = df_read(fpath)
+            # add invalidated
+            df2: pd.DataFrame = df_read(fpath.replace("validated", "invalidated"))
+            if df2.shape[0] > 0:
+                df_orig = pd.concat([df_orig, df2])
+            # df_orig = pd.concat([df_orig.astype(df2.dtypes), df2.astype(df_orig.dtypes)])
+            # df_orig = pd.concat([df_orig.loc[:], df2])
+            # df_orig = pd.concat([df_orig.loc[:].astype(df2.dtypes), df2.astype(df_orig.dtypes)])
+            # add other
+            df2: pd.DataFrame = df_read(fpath.replace("validated", "other"))
+            if df2.shape[0] > 0:
+                df_orig = pd.concat([df_orig, df2])
+            # df_orig = pd.concat([df_orig.astype(df2.dtypes), df2.astype(df_orig.dtypes)])
+            # df_orig = pd.concat([df_orig.loc[:], df2])
 
         # default result values
         res: SplitStatsRec = SplitStatsRec(ver=ver, lc=lc, alg=algorithm, sp=split)
@@ -556,7 +617,8 @@ def handle_dataset_splits(ds_path: str) -> list[SplitStatsRec]:
             return res
 
         # Replace NA with NODATA
-        df: pd.DataFrame = df_orig.fillna(value=c.NODATA)
+        # df: pd.DataFrame = df_orig.fillna(value=c.NODATA)
+        df: pd.DataFrame = df_orig.replace(float("nan"), c.NODATA)
         # backmap genders
         df = gender_backmapping(df)
         # add lowercase sentence column
@@ -812,7 +874,7 @@ def handle_dataset_splits(ds_path: str) -> list[SplitStatsRec]:
     # cd_file: str = os.path.join(cd_dir, '$clip_durations.tsv')
     cd_file: str = os.path.join(cd_dir, "clip_durations.tsv")
     df_clip_durations: pd.DataFrame = pd.DataFrame(
-        columns=c.COLS_CLIP_DURATIONS
+        columns=c.FIELDS_CLIP_DURATIONS
     ).set_index("clip")
     if os.path.isfile(cd_file):
         df_clip_durations = df_read(cd_file).set_index("clip")
@@ -883,6 +945,9 @@ def handle_dataset_splits(ds_path: str) -> list[SplitStatsRec]:
     return res
 
 
+# END - Dataset Split Stats (MP Handler)
+
+
 ########################################################
 # MAIN PROCESS
 ########################################################
@@ -891,10 +956,12 @@ def handle_dataset_splits(ds_path: str) -> list[SplitStatsRec]:
 def main() -> None:
     """Compile all data by calculating stats"""
 
-    dst_json_base: str = os.path.join(
+    res_json_base_dir: str = os.path.join(
         HERE, c.DATA_DIRNAME, c.RES_DIRNAME, c.JSON_DIRNAME
     )
-    dst_tsv_base: str = os.path.join(HERE, c.DATA_DIRNAME, c.RES_DIRNAME, c.TSV_DIRNAME)
+    res_tsv_base_dir: str = os.path.join(
+        HERE, c.DATA_DIRNAME, c.RES_DIRNAME, c.TSV_DIRNAME
+    )
 
     def ver2vercol(ver: str) -> str:
         """Converts a data version in format '11.0' to column/variable name format 'v11_0'"""
@@ -912,29 +979,30 @@ def main() -> None:
         def save_results() -> pd.DataFrame:
             """Temporarily or finally save the returned results"""
             df: pd.DataFrame = pd.DataFrame(
-                results, columns=c.COLS_TC_STATS
+                results, columns=c.FIELDS_TC_STATS
             ).reset_index(drop=True)
             df.sort_values(["lc", "ver"], inplace=True)
             # Write out combined (TSV only to use later for above existence checks)
-            df_write(df, os.path.join(dst_tsv_base, f"${c.TEXT_CORPUS_STATS_FN}.tsv"))
+            df_write(
+                df, os.path.join(res_tsv_base_dir, f"${c.TEXT_CORPUS_STATS_FN}.tsv")
+            )
             return df
 
         print("\n=== Start Text Corpora Analysis ===")
 
-        tc_base: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME)
+        tc_base_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME)
         combined_tsv_file: str = os.path.join(
-            dst_tsv_base, f"${c.TEXT_CORPUS_STATS_FN}.tsv"
+            res_tsv_base_dir, f"${c.TEXT_CORPUS_STATS_FN}.tsv"
         )
         # Get joined TSV
-        combined_df: pd.DataFrame = pd.DataFrame(columns=c.COLS_TC_STATS)
+        combined_ver_lc: list[str] = []
         if os.path.isfile(combined_tsv_file):
-            combined_df = df_read(combined_tsv_file).reset_index(drop=True)
-        combined_df = combined_df[["ver", "lc"]]
-        combined_ver_lc: list[str] = [
-            "|".join(row) for row in combined_df.values.tolist()
-        ]
-        del combined_df
-        combined_df = pd.DataFrame()
+            combined_ver_lc = [
+                "|".join(row)
+                for row in df_read(combined_tsv_file)
+                .reset_index(drop=True)[["ver", "lc"]]
+                .values.tolist()
+            ]
 
         ver_lc_list: list[str] = []  # final
         # start with newer, thus larger / longer versions' data
@@ -942,11 +1010,29 @@ def main() -> None:
         versions.reverse()
         # For each version
         for ver in versions:
-            ver_dir: str = calc_dataset_prefix(ver)
+            # ver_dir: str = calc_dataset_prefix(ver)
 
             # get all possible
             lc_list: list[str] = get_locales_from_cv_dataset(ver)
             g_tc.total_lc += len(lc_list)
+
+            # Get list of existing processed text corpus files, in reverse size order
+            # then get a list of language codes in that order
+            # This assumes that the larger the latest TC, the larger data we will have in previous versions,
+            # so that multiprocessing is maximized
+            pp: list[str] = glob.glob(
+                os.path.join(
+                    HERE, c.DATA_DIRNAME, c.TC_DIRNAME, "**", f"{c.TEXT_CORPUS_FN}.tsv"
+                )
+            )
+            lc_complete_list: list[str] = [
+                p.split(os.sep)[-2] for p in sort_by_largest_file(pp)
+            ]
+            lc_list = (
+                [lc for lc in lc_complete_list if lc in lc_list]
+                if not conf.DEBUG
+                else conf.DEBUG_CV_LC
+            )
 
             # remove already calculated ones
             if conf.FORCE_CREATE_TC_STATS:
@@ -959,10 +1045,9 @@ def main() -> None:
                 for lc in lc_list:
                     ver_lc: str = f"{ver}|{lc}"
                     tc_tsv: str = os.path.join(
-                        tc_base,
-                        ver_dir,
+                        tc_base_dir,
                         lc,
-                        f"{c.TEXT_CORPUS_FN}.tsv",
+                        f"{c.TEXT_CORPUS_FN}_{ver}.tsv",
                     )
                     if ver_lc in combined_ver_lc:
                         g_tc.skipped_exists += 1
@@ -970,14 +1055,15 @@ def main() -> None:
                         g_tc.skipped_nodata += 1
                     else:
                         ver_lc_new.append(ver_lc)
-                num_to_process: int = len(ver_lc_new)
+                new_num_to_process: int = len(ver_lc_new)
                 ver_lc_list.extend(ver_lc_new)
-                g_tc.processed_lc += num_to_process
-                g_tc.processed_ver += 1 if num_to_process > 0 else 0
+                g_tc.processed_lc += new_num_to_process
+                g_tc.processed_ver += 1 if new_num_to_process > 0 else 0
 
         # Now multi-process each record
         num_items: int = len(ver_lc_list)
         if num_items == 0:
+            report_results(g_tc)
             print("Nothing to process...")
             return
 
@@ -1005,7 +1091,7 @@ def main() -> None:
 
         # Create result DF
         print(">>> Finished... Now saving...")
-        df: pd.DataFrame = save_results() # final save
+        df: pd.DataFrame = save_results()  # final save
 
         # Write out under locale dir (data/results/<lc>/<lc>_<ver>_tc_stats.json|tsv)
         df2: pd.DataFrame = pd.DataFrame()
@@ -1017,14 +1103,14 @@ def main() -> None:
                     df_write(
                         df2,
                         os.path.join(
-                            dst_tsv_base,
+                            res_tsv_base_dir,
                             lc,
                             f"${lc}_{ver}_{c.TEXT_CORPUS_STATS_FN}.tsv",
                         ),
                     )
                     df2.to_json(
                         os.path.join(
-                            dst_json_base,
+                            res_json_base_dir,
                             lc,
                             f"${lc}_{ver}_{c.TEXT_CORPUS_STATS_FN}.json",
                         ),
@@ -1043,10 +1129,10 @@ def main() -> None:
 
         vc_base: str = os.path.join(HERE, c.DATA_DIRNAME, c.VC_DIRNAME)
         combined_tsv_file: str = os.path.join(
-            dst_tsv_base, f"{c.REPORTED_STATS_FN}.tsv"
+            res_tsv_base_dir, f"{c.REPORTED_STATS_FN}.tsv"
         )
         # Get joined TSV
-        combined_df: pd.DataFrame = pd.DataFrame(columns=c.COLS_REPORTED_STATS)
+        combined_df: pd.DataFrame = pd.DataFrame(columns=c.FIELDS_REPORTED_STATS)
         if os.path.isfile(combined_tsv_file):
             combined_df = df_read(combined_tsv_file).reset_index(drop=True)
         combined_df = combined_df[["ver", "lc"]]
@@ -1056,8 +1142,8 @@ def main() -> None:
         del combined_df
         combined_df = pd.DataFrame()
 
-        ver_lc_list: list[str] = []  # final
         # For each version
+        ver_lc_list: list[str] = []  # final
         for ver in c.CV_VERSIONS:
             ver_dir: str = calc_dataset_prefix(ver)
 
@@ -1121,7 +1207,7 @@ def main() -> None:
         df.sort_values(["lc", "ver"], inplace=True)
 
         # Write out combined (TSV only to use later)
-        df_write(df, os.path.join(dst_tsv_base, f"{c.REPORTED_STATS_FN}.tsv"))
+        df_write(df, os.path.join(res_tsv_base_dir, f"{c.REPORTED_STATS_FN}.tsv"))
         # Write out per locale
         for lc in ALL_LOCALES:
             # pylint - false positive / fix not available yet: https://github.com/UCL/TLOmodel/pull/1193
@@ -1129,14 +1215,14 @@ def main() -> None:
             df_write(
                 df_lc,
                 os.path.join(
-                    dst_tsv_base,
+                    res_tsv_base_dir,
                     lc,
                     f"{c.REPORTED_STATS_FN}.tsv",
                 ),
             )
             df_lc.to_json(
                 os.path.join(
-                    dst_json_base,
+                    res_json_base_dir,
                     lc,
                     f"{c.REPORTED_STATS_FN}.json",
                 ),
@@ -1350,8 +1436,8 @@ def main() -> None:
     # SPLITS
     if not conf.SKIP_VOICE_CORPORA:
         main_splits()
-    # SUPPORT MATRIX
-    main_support_matrix()
+        # SUPPORT MATRIX
+        main_support_matrix()
 
     # [TODO] Fix DEM correction problem !!!
     # [TODO] Get CV-Wide Datasets => Measures / Totals

--- a/lib.py
+++ b/lib.py
@@ -28,13 +28,14 @@ import conf
 def init_directories(basedir: str) -> None:
     """Creates data directory structures"""
     data_dir: str = os.path.join(basedir, c.DATA_DIRNAME)
-    if os.path.isfile(os.path.join(data_dir, ".gitkeep")):
-        return
+    # if os.path.isfile(os.path.join(data_dir, ".gitkeep")):
+    #     return
 
     print("Preparing directory structures...")
     all_locales: list[str] = get_locales_from_cv_dataset(c.CV_VERSIONS[-1])
     for lc in all_locales:
         os.makedirs(os.path.join(data_dir, c.CD_DIRNAME, lc), exist_ok=True)
+        os.makedirs(os.path.join(data_dir, c.TC_DIRNAME, lc), exist_ok=True)
         os.makedirs(
             os.path.join(data_dir, c.RES_DIRNAME, c.TSV_DIRNAME, lc), exist_ok=True
         )
@@ -43,14 +44,14 @@ def init_directories(basedir: str) -> None:
         )
     for ver in c.CV_VERSIONS:
         ver_lc: list[str] = get_locales_from_cv_dataset(ver)
+        ds_prefix: str = calc_dataset_prefix(ver)
+        os.makedirs(
+            os.path.join(data_dir, c.TC_ANALYSIS_DIRNAME, ds_prefix),
+            exist_ok=True,
+        )
         for lc in ver_lc:
-            ds_dir: str = os.path.join(calc_dataset_prefix(ver), lc)
             os.makedirs(
-                os.path.join(data_dir, c.TC_DIRNAME, ds_dir),
-                exist_ok=True,
-            )
-            os.makedirs(
-                os.path.join(data_dir, c.VC_DIRNAME, ds_dir),
+                os.path.join(data_dir, c.VC_DIRNAME, ds_prefix, lc),
                 exist_ok=True,
             )
     # create .gitkeep
@@ -70,6 +71,9 @@ def init_directories(basedir: str) -> None:
         encoding="utf8",
     ).close()
     open(os.path.join(data_dir, c.TC_DIRNAME, ".gitkeep"), "a", encoding="utf8").close()
+    open(
+        os.path.join(data_dir, c.TC_ANALYSIS_DIRNAME, ".gitkeep"), "a", encoding="utf8"
+    ).close()
     open(os.path.join(data_dir, c.VC_DIRNAME, ".gitkeep"), "a", encoding="utf8").close()
 
     # outside common cache

--- a/lib.py
+++ b/lib.py
@@ -168,9 +168,15 @@ def df_int_convert(x: pd.Series) -> Any:
     except ValueError as e:  # pylint: disable=W0612
         return x
 
+
 def df_concat(df1: pd.DataFrame, df2: pd.DataFrame) -> pd.DataFrame:
     """Controlled concat of two dataframes"""
-    return df1 if df2.shape[0] == 0 else df2 if df1.shape[0] == 0 else pd.concat([df1, df2])
+    return (
+        df1
+        if df2.shape[0] == 0
+        else df2 if df1.shape[0] == 0 else pd.concat([df1, df2])
+    )
+
 
 #
 # GIT
@@ -325,6 +331,7 @@ def arr2str(arr: list[list[Any]]) -> str:
     """Convert an array (list of lists) into a string"""
     return c.SEP_ROW.join(list2str(x) for x in arr)
 
+
 # def flatten(arr: list[list[Any]]) -> list[Any]:
 #     """Flattens a list of lists to a single list"""
 #     res: list[Any] = []
@@ -338,9 +345,11 @@ def arr2str(arr: list[list[Any]]) -> str:
 # Numbers
 #
 
+
 def dec3(x: float) -> float:
     """Make to 3 decimals"""
     return round(1000 * x) / 1000
+
 
 #
 # FS
@@ -350,8 +359,9 @@ def sort_by_largest_file(fpaths: list[str]) -> list[str]:
     recs: list[list[str | int]] = []
     for p in fpaths:
         recs.append([p, os.path.getsize(p)])
-    recs = sorted(recs, key=(lambda x: x[1]) ,reverse=True)
+    recs = sorted(recs, key=(lambda x: x[1]), reverse=True)
     return [str(row[0]) for row in recs]
+
 
 #
 # Gender back-mapping

--- a/lib.py
+++ b/lib.py
@@ -118,24 +118,27 @@ def report_results(g: Globals) -> None:
 # def df_read(fpath: str, dtypes: defaultdict = defaultdict(str)) -> pd.DataFrame:
 def df_read(fpath: str, dtype: dict | None = None) -> pd.DataFrame:
     """Read a tsv file into a dataframe"""
+    _df: pd.DataFrame = pd.DataFrame()
     if not os.path.isfile(fpath):
         print(f"FATAL: File {fpath} cannot be located!")
         if conf.FAIL_ON_NOT_FOUND:
             sys.exit(1)
+        return _df
 
-    df: pd.DataFrame = pd.read_csv(
+    _df = pd.read_csv(
         fpath,
         sep="\t",
         parse_dates=False,
         encoding="utf-8",
-        on_bad_lines="skip",
-        # quotechar='"',
-        # quoting=csv.QUOTE_NONE,
-        engine="pyarrow",
+        # on_bad_lines="skip",
+        on_bad_lines="warn",
+        quotechar='"',
+        quoting=csv.QUOTE_NONE,
+        engine="python", #"pyarrow"
         dtype_backend="pyarrow",
         dtype=dtype,
     )
-    return df
+    return _df
 
 
 def df_write(df: pd.DataFrame, fpath: Any, mode: Any = "w") -> bool:

--- a/lib.py
+++ b/lib.py
@@ -93,7 +93,9 @@ def report_results(g: Globals) -> None:
     """Prints out simpğle report from global counters"""
     process_seconds: float = (datetime.now() - g.start_time).total_seconds()
     print("=" * 80)
-    print(f"Total\t\t: Ver: {g.total_ver} LC: {g.total_lc} Algo: {g.total_algo} Splits: {g.total_splits}")
+    print(
+        f"Total\t\t: Ver: {g.total_ver} LC: {g.total_lc} Algo: {g.total_algo} Splits: {g.total_splits}"
+    )
     print(
         f"Processed\t: Ver: {g.processed_ver} LC: {g.processed_lc} Algo: {g.processed_algo}"
     )
@@ -315,3 +317,12 @@ def arr2str(arr: list[list[Any]]) -> str:
 def dec3(x: float) -> float:
     """Make to 3 decimals"""
     return round(1000 * x) / 1000
+
+
+#
+# Gender back-mapping
+#
+def gender_backmapping(df: pd.DataFrame) -> pd.DataFrame:
+    """Backmap new genders back to older ones for backward compatibility"""
+    df["gender"] = df["gender"].replace(c.CV_GENDERS_MAPPING)
+    return df

--- a/lib.py
+++ b/lib.py
@@ -240,9 +240,16 @@ def is_version_valid(ver: str) -> Literal[True]:
     return True
 
 
-def calc_dataset_prefix(
-    ver: str,
-) -> str:
+def get_cutoff_date(ver: str) -> str:
+    """Given version, get the cutoff-date of that version"""
+
+    if is_version_valid(ver):
+        inx: int = c.CV_VERSIONS.index(ver)
+        return c.CV_DATES[inx]
+    return ""
+
+
+def calc_dataset_prefix(ver: str) -> str:
     """Build the dataset string from version (valid for > v4)"""
 
     if is_version_valid(ver):

--- a/pack_splits.py
+++ b/pack_splits.py
@@ -60,7 +60,6 @@ def handle_ds(dspath: str) -> None:
         conf.COMPRESSED_RESULTS_BASE_DIR, c.UPLOADED_DIRNAME, lc
     )
     os.makedirs(upload_dir, exist_ok=True)
-    print(f"Compressing Dataset Splits for {corpus} - {lc}", flush=True)
     for algo in c.ALGORITHMS:
         if os.path.isdir(os.path.join(dspath, algo)):  # check if algo exists at source
             tarpath1: str = os.path.join(upload_dir, f"{lc}_{ver}_{algo}")
@@ -70,6 +69,7 @@ def handle_ds(dspath: str) -> None:
                 not os.path.isfile(tarpath2 + ".tar.xz")
                 and not os.path.isfile(tarpath1 + ".tar.xz")
             ) or conf.FORCE_CREATE_COMPRESSED:
+                print(f"Compressing Dataset Splits for {corpus} - {lc}", flush=True)
                 shutil.make_archive(
                     base_name=tarpath1, format="xztar", root_dir=dspath, base_dir=algo
                 )

--- a/pack_splits.py
+++ b/pack_splits.py
@@ -41,7 +41,7 @@ if not HERE in sys.path:
     sys.path.append(HERE)
 
 # Program parameters
-PROC_COUNT: int = int(1.5 * psutil.cpu_count(logical=True))  # OVER usage
+PROC_COUNT: int = min(60, int(2 * psutil.cpu_count(logical=True)))  # OVER usage
 BATCH_SIZE: int = 5
 ALL_LOCALES: list[str] = get_locales_from_cv_dataset(c.CV_VERSIONS[-1])
 

--- a/split_compile.py
+++ b/split_compile.py
@@ -70,11 +70,14 @@ def main() -> None:
         src_dir = os.path.join(conf.SRC_BASE_DIR, c.ALGORITHMS[0], ver_dir, lc)
         dst_dir = os.path.join(vc_dir_base, ver_dir, lc)
         tsv_fpath: str = ""
+        
+        files_to_copy: list[str] = c.EXTENDED_BUCKET_FILES.copy()
+        files_to_copy.extend(c.TC_BUCKET_FILES)
 
         if conf.FORCE_CREATE_VC_STATS or not os.path.isfile(os.path.join(dst_dir, "validated.tsv")):
             # os.makedirs(os.path.join(dst_dir, c.ALGORITHMS[0]), exist_ok=True)
             os.makedirs(dst_dir, exist_ok=True)
-            for fn in c.EXTENDED_BUCKET_FILES:
+            for fn in files_to_copy:
                 tsv_fpath = os.path.join(src_dir, fn)
                 if os.path.isfile(tsv_fpath):
                     shutil.copy2(tsv_fpath, dst_dir)

--- a/split_compile.py
+++ b/split_compile.py
@@ -70,11 +70,13 @@ def main() -> None:
         src_dir = os.path.join(conf.SRC_BASE_DIR, c.ALGORITHMS[0], ver_dir, lc)
         dst_dir = os.path.join(vc_dir_base, ver_dir, lc)
         tsv_fpath: str = ""
-        
+
         files_to_copy: list[str] = c.EXTENDED_BUCKET_FILES.copy()
         files_to_copy.extend(c.TC_BUCKET_FILES)
 
-        if conf.FORCE_CREATE_VC_STATS or not os.path.isfile(os.path.join(dst_dir, "validated.tsv")):
+        if conf.FORCE_CREATE_VC_STATS or not os.path.isfile(
+            os.path.join(dst_dir, "validated.tsv")
+        ):
             # os.makedirs(os.path.join(dst_dir, c.ALGORITHMS[0]), exist_ok=True)
             os.makedirs(dst_dir, exist_ok=True)
             for fn in files_to_copy:
@@ -88,7 +90,9 @@ def main() -> None:
 
         # copy to s1
         dst_dir = os.path.join(vc_dir_base, ver_dir, lc, c.ALGORITHMS[0])
-        if conf.FORCE_CREATE_VC_STATS or not os.path.isfile(os.path.join(dst_dir, "train.tsv")):
+        if conf.FORCE_CREATE_VC_STATS or not os.path.isfile(
+            os.path.join(dst_dir, "train.tsv")
+        ):
             os.makedirs(dst_dir, exist_ok=True)
             for fn in c.SPLIT_FILES:
                 tsv_fpath = os.path.join(src_dir, fn)
@@ -104,7 +108,9 @@ def main() -> None:
             src_dir = os.path.join(conf.SRC_BASE_DIR, algo, ver_dir, lc)
             if os.path.isdir(src_dir):
                 dst_dir = os.path.join(vc_dir_base, ver_dir, lc, algo)
-                if conf.FORCE_CREATE_VC_STATS or not os.path.isfile(os.path.join(dst_dir, "train.tsv")):
+                if conf.FORCE_CREATE_VC_STATS or not os.path.isfile(
+                    os.path.join(dst_dir, "train.tsv")
+                ):
                     os.makedirs(dst_dir, exist_ok=True)
                     for fn in c.SPLIT_FILES:
                         tsv_fpath = os.path.join(src_dir, fn)
@@ -140,9 +146,7 @@ def main() -> None:
     for ver in c.CV_VERSIONS:
         # Check if it exists in source (check "s1", if not there, it is nowhere)
         ver_dir = calc_dataset_prefix(ver)
-        if not os.path.isdir(
-            os.path.join(conf.SRC_BASE_DIR, c.ALGORITHMS[0], ver_dir)
-        ):
+        if not os.path.isdir(os.path.join(conf.SRC_BASE_DIR, c.ALGORITHMS[0], ver_dir)):
             continue  # Does not exist, so skip
 
         # Create destination
@@ -163,9 +167,7 @@ def main() -> None:
         # print("=" * 80)
         # print(f"Processing {lc_cnt} locales in {cv_dir_name}")
 
-        pbar_lc = tqdm(
-            lc_list, desc=("   v" + ver)[-5:], total=lc_cnt, unit=" Locale"
-        )
+        pbar_lc = tqdm(lc_list, desc=("   v" + ver)[-5:], total=lc_cnt, unit=" Locale")
         for lc in lc_list:
             handle_locale(lc)
             pbar_lc.update()

--- a/text_corpus_compile.py
+++ b/text_corpus_compile.py
@@ -16,6 +16,7 @@
 ###########################################################################
 
 # Standard Lib
+# from ast import literal_eval
 import sys
 import os
 import glob
@@ -32,6 +33,7 @@ import const as c
 import conf
 from lib import (
     calc_dataset_prefix,
+    df_concat,
     df_read,
     df_write,
     get_cutoff_date,
@@ -40,6 +42,7 @@ from lib import (
     git_clone_or_pull_all,
     init_directories,
     report_results,
+    sort_by_largest_file,
 )
 from typedef import Globals
 
@@ -50,7 +53,8 @@ if not HERE in sys.path:
     sys.path.append(HERE)
 
 PROC_COUNT: int = psutil.cpu_count(logical=True)  # Full usage
-MAX_BATCH_SIZE: int = 5
+MAX_BATCH_SIZE: int = 1
+used_proc_count: int = conf.DEBUG_PROC_COUNT if conf.DEBUG else PROC_COUNT
 
 cv: cvu.CV = cvu.CV()
 VALIDATORS: list[str] = cv.validators()
@@ -63,12 +67,54 @@ g: Globals = Globals(
     total_algo=len(c.ALGORITHMS),
 )
 
+
+#
+# This is temporary for handling malformed validated_sentences.tsv of v17.0
+#
+
+
+def df_read_safe_tc_validated(fpath: str) -> pd.DataFrame:
+    """Read in possibly malformed validated_sentences.tsv file"""
+    lines_read: list[str] = []
+    final_arr: list[list[str]] = []
+    # read all data and split to lines
+    with open(fpath, encoding="utf8") as fd:
+        lines_read: list[str] = fd.read().splitlines()
+
+    # first line is column names, so we skip it because we predefine them
+    cur_source_line: int = 1
+    while cur_source_line < len(lines_read):
+        line: str = lines_read[cur_source_line].replace("\n", " ").replace("  ", " ")
+        # if there are 6 columns, we are OK, else we append next line to this.
+        if len(line.split("\t")) < len(c.FIELDS_TC_VALIDATED) and cur_source_line < len(
+            lines_read
+        ):
+            if cur_source_line >= len(lines_read) - 1:
+                break
+            # not EOF
+            next_line: str = lines_read[cur_source_line + 1].replace("\n", "")
+            line += next_line
+            cur_source_line += 1  # extra inc
+        # normal inc
+        cur_source_line += 1
+        # add to final
+        v: list[str] = line.split("\t")
+        if len(v) == 6:
+            final_arr.append(v)
+
+    # _df: pd.DataFrame = pd.DataFrame(final_arr, columns=c.COLS_TC_VALIDATED).drop_duplicates()
+    _df: pd.DataFrame = pd.DataFrame(
+        final_arr, columns=c.FIELDS_TC_VALIDATED
+    ).drop_duplicates()
+    return _df
+
+
 #
 # LAST VERSION HANDLERS
 #
 
 
-def handle_last_version_locale(ver_lc: str) -> None:
+def handle_last_version_locale(ver_lc: str) -> str:
     """Process to handle a single locale in last version"""
 
     def handle_preprocess(df_base: pd.DataFrame, df_new: pd.DataFrame) -> pd.DataFrame:
@@ -81,7 +127,8 @@ def handle_last_version_locale(ver_lc: str) -> None:
 
         # pre-calc simpler values
         df_new["char_cnt"] = [
-            len(s) if isinstance(s, str) else 0 for s in df_new["sentence"].to_list()
+            str(len(s)) if isinstance(s, str) else "0"
+            for s in df_new["sentence"].to_list()
         ]
 
         # validator dependent
@@ -91,14 +138,14 @@ def handle_last_version_locale(ver_lc: str) -> None:
                 for s in df_new["sentence"].tolist()
             ]
             df_new["valid"] = [
-                0 if n is None else 1 for n in df_new["normalized"].tolist()
+                "0" if n is None else "1" for n in df_new["normalized"].tolist()
             ]
             df_new["tokens"] = [
                 None if s is None else tokeniser.tokenise(s)
                 for s in df_new["normalized"].tolist()
             ]
             df_new["word_cnt"] = [
-                None if ww is None else len(ww) for ww in df_new["tokens"].tolist()
+                None if ww is None else str(len(ww)) for ww in df_new["tokens"].tolist()
             ]
 
         # phonemiser dependent
@@ -109,20 +156,13 @@ def handle_last_version_locale(ver_lc: str) -> None:
                 # for w in str(s).split(" ")
             ]
         # return with newly processed data added
-        return pd.concat([df_base.astype(df_new.dtypes), df_new.astype(df_base.dtypes)])
+        return df_concat(df_base, df_new)
 
     # handle_locale MAIN
+    # print("PROCESSING=", ver_lc)
     ver: str = ver_lc.split("|")[0]
     lc: str = ver_lc.split("|")[1]
     ver_dir: str = calc_dataset_prefix(ver)
-
-    # precalc dir and file paths
-    base_tc_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME, lc)
-    os.makedirs(base_tc_dir, exist_ok=True)
-    base_tc_file: str = os.path.join(base_tc_dir, f"{c.TEXT_CORPUS_FN}.tsv")
-    src_tc_val_file: str = os.path.join(
-        HERE, c.DATA_DIRNAME, c.VC_DIRNAME, ver_dir, lc, c.TC_VALIDATED_FILE
-    )
 
     # cvu - do we have them?
     validator: cvu.Validator | None = cvu.Validator(lc) if lc in VALIDATORS else None
@@ -132,13 +172,31 @@ def handle_last_version_locale(ver_lc: str) -> None:
     tokeniser: cvu.Tokeniser = cvu.Tokeniser(lc)
 
     # get existing base (already preprocessed) and new validated dataframes
-    df_base: pd.DataFrame = pd.DataFrame(columns=c.COLS_TEXT_CORPUS)
+    # df_base: pd.DataFrame = pd.DataFrame(columns=c.COLS_TEXT_CORPUS, dtype=c.DTYPES_TEXT_CORPUS)
+    base_tc_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME, lc)
+    os.makedirs(base_tc_dir, exist_ok=True)
+    base_tc_file: str = os.path.join(base_tc_dir, f"{c.TEXT_CORPUS_FN}.tsv")
+    df_base: pd.DataFrame = pd.DataFrame(columns=c.FIELDS_TEXT_CORPUS)
     if os.path.isfile(base_tc_file):
         df_base = df_read(base_tc_file)
-    df_tc_val: pd.DataFrame = df_read(src_tc_val_file)
-    df_tc_val.reindex(columns=c.COLS_TEXT_CORPUS)  # add new columns
 
-    df_write(handle_preprocess(df_base, df_tc_val), base_tc_file)  # write-out result
+    # df_tc_val: pd.DataFrame = df_read(src_tc_val_file)
+    src_tc_val_file: str = os.path.join(
+        HERE, c.DATA_DIRNAME, c.VC_DIRNAME, ver_dir, lc, c.TC_VALIDATED_FILE
+    )
+    df_tc_val: pd.DataFrame = df_read_safe_tc_validated(src_tc_val_file)
+    df_tc_val = df_tc_val.reindex(columns=c.FIELDS_TEXT_CORPUS)  # add new columns
+
+    # write-out result
+    df_new_tc: pd.DataFrame = handle_preprocess(df_base, df_tc_val)
+    if df_base.shape[0] != df_new_tc.shape[0]:
+        df_write(df_new_tc, base_tc_file)
+    # create index file for the last version
+    df_write(
+        df_new_tc["sentence_id"].to_frame().sort_values("sentence_id"),
+        os.path.join(base_tc_dir, f"{c.TEXT_CORPUS_FN}_{ver}.tsv"),
+    )
+    return ver_lc
 
 
 def handle_last_version() -> None:
@@ -153,12 +211,32 @@ def handle_last_version() -> None:
     lc_list: list[str] = get_locales_from_cv_dataset(ver)
     total_locales: int = len(lc_list)
 
+    # Get list of new validated_sentences files, in reverse size order
+    # then get a list of language codes in that order
+    # This executes larger data first, so that multiprocessing is maximized
+    pp: list[str] = glob.glob(
+        os.path.join(
+            HERE,
+            c.DATA_DIRNAME,
+            c.VC_DIRNAME,
+            calc_dataset_prefix(ver),
+            "**",
+            c.TC_VALIDATED_FILE,
+        )
+    )
+    lc_list = (
+        [p.split(os.sep)[-2] for p in sort_by_largest_file(pp)]
+        if not conf.DEBUG
+        else conf.DEBUG_CV_LC
+    )
     # Filter out already processed
     tc_base_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME)
     ver_lc_list: list[str] = [
         f"{ver}|{lc}"
         for lc in lc_list
-        if not os.path.isfile(os.path.join(tc_base_dir, lc, f"{c.TEXT_CORPUS_FN}_{ver}.tsv"))
+        if not os.path.isfile(
+            os.path.join(tc_base_dir, lc, f"{c.TEXT_CORPUS_FN}_{ver}.tsv")
+        )
         or conf.FORCE_CREATE_TC_STATS
     ]
     num_locales: int = len(ver_lc_list)
@@ -166,19 +244,22 @@ def handle_last_version() -> None:
     # Handle remaining locales in multi-processing
     chunk_size: int = min(
         MAX_BATCH_SIZE,
-        num_locales // PROC_COUNT + (0 if num_locales % PROC_COUNT == 0 else 1),
+        num_locales // used_proc_count
+        + (0 if num_locales % used_proc_count == 0 else 1),
     )
     print(
         f"Total: {total_locales} Existing: {total_locales-num_locales} Remaining: {num_locales} "
-        + f"Procs: {PROC_COUNT}  chunk_size: {chunk_size}..."
+        + f"Procs: {used_proc_count}  chunk_size: {chunk_size}..."
     )
 
     if num_locales > 0:
-        with mp.Pool(PROC_COUNT) as pool:
-            with tqdm(total=num_locales, desc="") as pbar:
-                for _ in pool.imap_unordered(
+        print(f"Processing: {[x.split(" | ")[1] for x in ver_lc_list]}")
+        with mp.Pool(used_proc_count) as pool:
+            with tqdm(total=num_locales, desc="Locales") as pbar:
+                for res in pool.imap_unordered(
                     handle_last_version_locale, ver_lc_list, chunksize=chunk_size
                 ):
+                    pbar.write(f"Finished: {res}")
                     pbar.update()
 
     g.total_lc += total_locales
@@ -188,45 +269,48 @@ def handle_last_version() -> None:
 
 
 #
-# OLD VERSION HANDLERS
+# OLD VERSION HANDLERS (Creates files which include only sentence_index)
 #
 
 
-def handle_old_version_locale(ver_lc: str) -> None:
+def handle_old_version_locale(ver_lc: str) -> str:
     """Process to handle a single locale in older versions"""
 
     # handle_locale MAIN
     ver: str = ver_lc.split("|")[0]
     lc: str = ver_lc.split("|")[1]
-    ver_dir: str = calc_dataset_prefix(ver)
+    # ver_dir: str = calc_dataset_prefix(ver)
 
     # precalc dir and file paths
     base_tc_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME, lc)
     base_tc_file: str = os.path.join(base_tc_dir, f"{c.TEXT_CORPUS_FN}.tsv")
     ver_tc_file: str = os.path.join(base_tc_dir, f"{c.TEXT_CORPUS_FN}_{ver}.tsv")
-    ver_vc_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.VC_DIRNAME, ver_dir, lc)
+    # ver_vc_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.VC_DIRNAME, ver_dir, lc)
 
     # get existing base (already preprocessed) and new validated dataframes
-    df_base: pd.DataFrame = df_read(base_tc_file)
-    df: pd.DataFrame = pd.DataFrame(columns=["sentence_id"])
+    df_base: pd.DataFrame = pd.DataFrame(columns=c.FIELDS_TEXT_CORPUS)
+    # NotImplementedError: Converting strings to list<item: string> is not implemented.
+    # df_base = df_read(fpath=base_tc_file, dtype=c.FIELDS_TEXT_CORPUS)
+    df_base = df_read(fpath=base_tc_file)
+    # df_base = df_base[ df_base["is_used"] == "1" ][["sentence_id", "sentence"]] # we only need these
+    df_base = df_base[df_base["is_used"] == 1]  # we only need these
+    df_indexes: pd.DataFrame = pd.DataFrame(columns=["sentence_id"])
     # For versions v17.0 and later, we just use the main text_corpora file - even current is generated
     if float(ver) >= 17.0:
-        df = pd.DataFrame(df_base["sentence_id"]).drop_duplicates().dropna().sort_values("sentence_id")
-        df_write(df, ver_tc_file)
-        return
+        df_indexes = (
+            df_base["sentence_id"]
+            .to_frame()
+            .dropna()
+            .drop_duplicates()
+            .sort_values("sentence_id")
+        )
+        df_write(df_indexes, ver_tc_file)
+        return ver_lc
 
     # ELSE- For versions before v17.0, get the data from github clone + main buckets
     # These do not have "sentence_id" field, thus we need to use the "sentence" field to locate them
 
-    # Get sentences from major buckets
     sentences: list[str] = []
-    for bucket in c.MAIN_BUCKETS:
-        ver_vc_bucket_file: str = os.path.join(ver_vc_dir, f"{bucket}.tsv")
-        if os.path.isfile(ver_vc_bucket_file):
-            df_temp: pd.DataFrame = df_read(ver_vc_bucket_file)
-            sentences.extend(df_temp["sentence"].to_list())
-    # remove duplicates
-    sentences = list(set(sentences))
 
     # get sentences from git clone server/data/<lc>/*.txt
     git_data_path: str = os.path.join(
@@ -237,15 +321,41 @@ def handle_old_version_locale(ver_lc: str) -> None:
     )
     for fn in file_list:
         with open(fn, encoding="utf8") as fd:
-            sentences.extend(fd.readlines())
-    # re-remove duplicates
-    sentences = list(set(sentences))
+            sentences.extend(fd.read().splitlines())
+    # make unique & get rid of new lines
+    # sentences = [line.replace("\n", "").replace("\t", " ").replace("  ", " ") for line in sentences]
+    sentences = [s for s in list(set(sentences)) if s]
 
-    # Now get the subset
-    df_subset: pd.DataFrame = df_base[df_base["sentence"].isin(sentences)].drop_duplicates()
-    df_sen_id: pd.DataFrame = df_subset["sentence_id"].to_frame().dropna().sort_values("sentence_id")
+    # [FIXME] The following does not work as the sentences are post-manipulated by CorporaCreator
+    # Get sentences from major buckets
+    # for bucket in c.MAIN_BUCKETS:
+    #     ver_vc_bucket_file: str = os.path.join(ver_vc_dir, f"{bucket}.tsv")
+    #     if os.path.isfile(ver_vc_bucket_file):
+    #         df_temp: pd.DataFrame = df_read(ver_vc_bucket_file)
+    #         sentences.extend(df_temp["sentence"].to_list())
+    # # remove duplicates
+    # sentences = list(set(sentences))
 
-    df_write(df_sen_id, ver_tc_file)  # write-out result
+    # now get a subset
+    df_subset: pd.DataFrame = df_base[df_base["sentence"].isin(sentences)]
+    # print(df_subset.shape[0])
+    df_indexes = (
+        df_subset["sentence_id"]
+        .to_frame()
+        .dropna()
+        .drop_duplicates()
+        .sort_values("sentence_id")
+    )
+    # debug df's
+    # df_sentences: pd.DataFrame = pd.DataFrame(sentences, columns=["sentence"])
+    # df_exluded: pd.DataFrame = df_base[~df_base["sentence"].isin(sentences)]
+    # df_write(df_sentences, os.path.join(base_tc_dir, f"{c.TEXT_CORPUS_FN}_{ver}_sentences.tsv"))
+    # df_write(df_subset, os.path.join(base_tc_dir, f"{c.TEXT_CORPUS_FN}_{ver}_subset.tsv"))
+    # df_write(df_exluded, os.path.join(base_tc_dir, f"{c.TEXT_CORPUS_FN}_{ver}_excluded.tsv"))
+
+    # write-out result
+    df_write(df_indexes, ver_tc_file)
+    return ver_lc
 
 
 def handle_older_version(ver: str) -> None:
@@ -253,12 +363,32 @@ def handle_older_version(ver: str) -> None:
 
     # Get the repo at cutoff date ([TODO] Need to compile real cut-off dates)
     cutoff_date: str = get_cutoff_date(ver)
-    print(f"=== HANDLE: v{ver} @ {cutoff_date} ===")
+    print(f"=== HANDLE INDEXING: v{ver} @ {cutoff_date} ===")
 
-    lc_list: list[str] = get_locales_from_cv_dataset(ver)
+    lc_list: list[str] = (
+        get_locales_from_cv_dataset(ver) if not conf.DEBUG else conf.DEBUG_CV_LC
+    )
     total_locales: int = len(lc_list)
 
-    # Filter out already processed
+    # Get list of existing processed text corpus files, in reverse size order
+    # then get a list of language codes in that order
+    # This assumes that the larger the latest TC, the larger data we will have in previous versions,
+    # so that multiprocessing is maximized
+    pp: list[str] = glob.glob(
+        os.path.join(
+            HERE, c.DATA_DIRNAME, c.TC_DIRNAME, "**", f"{c.TEXT_CORPUS_FN}.tsv"
+        )
+    )
+    lc_complete_list: list[str] = [
+        p.split(os.sep)[-2] for p in sort_by_largest_file(pp)
+    ]
+    lc_list = (
+        [lc for lc in lc_complete_list if lc in lc_list]
+        if not conf.DEBUG
+        else conf.DEBUG_CV_LC
+    )
+
+    # Get lc list and filter out already processed
     base_tc_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME)
     ver_lc_list: list[str] = [
         f"{ver}|{lc}"
@@ -273,20 +403,23 @@ def handle_older_version(ver: str) -> None:
     # Handle remaining locales in multi-processing
     chunk_size: int = min(
         MAX_BATCH_SIZE,
-        num_locales // PROC_COUNT + (0 if num_locales % PROC_COUNT == 0 else 1),
+        num_locales // used_proc_count
+        + (0 if num_locales % used_proc_count == 0 else 1),
     )
     print(
         f"Total: {total_locales} Existing: {total_locales-num_locales} Remaining: {num_locales} "
-        + f"Procs: {PROC_COUNT}  chunk_size: {chunk_size}..."
+        + f"Procs: {used_proc_count}  chunk_size: {chunk_size}..."
     )
 
     if num_locales > 0:
+        print(f"Processing: {[x.split(" | ")[1] for x in ver_lc_list]}")
         git_checkout(c.CV_GITREC, cutoff_date)
-        with mp.Pool(PROC_COUNT) as pool:
-            with tqdm(total=num_locales, desc="") as pbar:
-                for _ in pool.imap_unordered(
+        with mp.Pool(used_proc_count) as pool:
+            with tqdm(total=num_locales, desc="Locales") as pbar:
+                for res in pool.imap_unordered(
                     handle_old_version_locale, ver_lc_list, chunksize=chunk_size
                 ):
+                    pbar.write(f"Finished: {res}")
                     pbar.update()
 
     g.total_lc += total_locales
@@ -299,8 +432,6 @@ def handle_older_version(ver: str) -> None:
 def main() -> None:
     """Main function feeding the multi-processing pool"""
 
-    # we don't need the git clones after v17.0
-
     # Make sure clones are current
     git_checkout(c.CV_GITREC)
     git_clone_or_pull_all()
@@ -308,8 +439,12 @@ def main() -> None:
     # Do it only for last version (after v17.0)
     handle_last_version()
 
-    # Loop for versions, just to keep sentence_id info
-    for ver in c.CV_VERSIONS:
+    # Loop for versions in reverse, just to keep sentence_id info
+    rev_cv_versions: list[str] = (
+        c.CV_VERSIONS if not conf.DEBUG else conf.DEBUG_CV_VER
+    ).copy()
+    rev_cv_versions.reverse()
+    for ver in rev_cv_versions:
         handle_older_version(ver)
 
     # done, revert to main and report

--- a/text_corpus_compile.py
+++ b/text_corpus_compile.py
@@ -18,6 +18,7 @@
 # Standard Lib
 import sys
 import os
+import glob
 import multiprocessing as mp
 
 # External dependencies
@@ -33,6 +34,7 @@ from lib import (
     calc_dataset_prefix,
     df_read,
     df_write,
+    get_cutoff_date,
     get_locales_from_cv_dataset,
     git_checkout,
     git_clone_or_pull_all,
@@ -61,9 +63,13 @@ g: Globals = Globals(
     total_algo=len(c.ALGORITHMS),
 )
 
+#
+# LAST VERSION HANDLERS
+#
 
-def handle_locale(ver_lc: str) -> None:
-    """Process to handle a single locale"""
+
+def handle_last_version_locale(ver_lc: str) -> None:
+    """Process to handle a single locale in last version"""
 
     def handle_preprocess(df_base: pd.DataFrame, df_new: pd.DataFrame) -> pd.DataFrame:
         """Get whole data and only process the unprocessed ones, returns the full result"""
@@ -84,7 +90,9 @@ def handle_locale(ver_lc: str) -> None:
                 validator.validate(s) if isinstance(s, str) else None
                 for s in df_new["sentence"].tolist()
             ]
-            df_new["valid"] = [0 if n is None else 1 for n in df_new["normalized"].tolist()]
+            df_new["valid"] = [
+                0 if n is None else 1 for n in df_new["normalized"].tolist()
+            ]
             df_new["tokens"] = [
                 None if s is None else tokeniser.tokenise(s)
                 for s in df_new["normalized"].tolist()
@@ -117,9 +125,7 @@ def handle_locale(ver_lc: str) -> None:
     )
 
     # cvu - do we have them?
-    validator: cvu.Validator | None = (
-        cvu.Validator(lc) if lc in VALIDATORS else None
-    )
+    validator: cvu.Validator | None = cvu.Validator(lc) if lc in VALIDATORS else None
     phonemiser: cvu.Phonemiser | None = (
         cvu.Phonemiser(lc) if lc in PHONEMISERS else None
     )
@@ -136,7 +142,7 @@ def handle_locale(ver_lc: str) -> None:
 
 
 def handle_last_version() -> None:
-    """Handle a CV version"""
+    """Handle last CV version"""
 
     # Get the repo at cutoff date ([TODO] Need to compile real cut-off dates)
     ver: str = c.CV_VERSIONS[-1]
@@ -148,13 +154,11 @@ def handle_last_version() -> None:
     total_locales: int = len(lc_list)
 
     # Filter out already processed
-    tc_analysis_dir: str = os.path.join(
-        HERE, c.DATA_DIRNAME, c.TC_ANALYSIS_DIRNAME, calc_dataset_prefix(ver)
-    )
+    tc_base_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME)
     ver_lc_list: list[str] = [
         f"{ver}|{lc}"
         for lc in lc_list
-        if not os.path.isdir(os.path.join(tc_analysis_dir, lc))
+        if not os.path.isfile(os.path.join(tc_base_dir, lc, f"{c.TEXT_CORPUS_FN}_{ver}.tsv"))
         or conf.FORCE_CREATE_TC_STATS
     ]
     num_locales: int = len(ver_lc_list)
@@ -173,7 +177,115 @@ def handle_last_version() -> None:
         with mp.Pool(PROC_COUNT) as pool:
             with tqdm(total=num_locales, desc="") as pbar:
                 for _ in pool.imap_unordered(
-                    handle_locale, ver_lc_list, chunksize=chunk_size
+                    handle_last_version_locale, ver_lc_list, chunksize=chunk_size
+                ):
+                    pbar.update()
+
+    g.total_lc += total_locales
+    g.processed_ver += 1
+    g.processed_lc += num_locales
+    g.skipped_exists += total_locales - num_locales
+
+
+#
+# OLD VERSION HANDLERS
+#
+
+
+def handle_old_version_locale(ver_lc: str) -> None:
+    """Process to handle a single locale in older versions"""
+
+    # handle_locale MAIN
+    ver: str = ver_lc.split("|")[0]
+    lc: str = ver_lc.split("|")[1]
+    ver_dir: str = calc_dataset_prefix(ver)
+
+    # precalc dir and file paths
+    base_tc_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME, lc)
+    base_tc_file: str = os.path.join(base_tc_dir, f"{c.TEXT_CORPUS_FN}.tsv")
+    ver_tc_file: str = os.path.join(base_tc_dir, f"{c.TEXT_CORPUS_FN}_{ver}.tsv")
+    ver_vc_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.VC_DIRNAME, ver_dir, lc)
+
+    # get existing base (already preprocessed) and new validated dataframes
+    df_base: pd.DataFrame = df_read(base_tc_file)
+    df: pd.DataFrame = pd.DataFrame(columns=["sentence_id"])
+    # For versions v17.0 and later, we just use the main text_corpora file - even current is generated
+    if float(ver) >= 17.0:
+        df = pd.DataFrame(df_base["sentence_id"]).drop_duplicates().dropna().sort_values("sentence_id")
+        df_write(df, ver_tc_file)
+        return
+
+    # ELSE- For versions before v17.0, get the data from github clone + main buckets
+    # These do not have "sentence_id" field, thus we need to use the "sentence" field to locate them
+
+    # Get sentences from major buckets
+    sentences: list[str] = []
+    for bucket in c.MAIN_BUCKETS:
+        ver_vc_bucket_file: str = os.path.join(ver_vc_dir, f"{bucket}.tsv")
+        if os.path.isfile(ver_vc_bucket_file):
+            df_temp: pd.DataFrame = df_read(ver_vc_bucket_file)
+            sentences.extend(df_temp["sentence"].to_list())
+    # remove duplicates
+    sentences = list(set(sentences))
+
+    # get sentences from git clone server/data/<lc>/*.txt
+    git_data_path: str = os.path.join(
+        conf.CV_TBOX_CACHE, "clones", "common-voice", "server", "data", lc
+    )
+    file_list: list[str] = glob.glob(
+        os.path.join(git_data_path, "*.txt"), recursive=False
+    )
+    for fn in file_list:
+        with open(fn, encoding="utf8") as fd:
+            sentences.extend(fd.readlines())
+    # re-remove duplicates
+    sentences = list(set(sentences))
+
+    # Now get the subset
+    df_subset: pd.DataFrame = df_base[df_base["sentence"].isin(sentences)].drop_duplicates()
+    df_sen_id: pd.DataFrame = df_subset["sentence_id"].to_frame().dropna().sort_values("sentence_id")
+
+    df_write(df_sen_id, ver_tc_file)  # write-out result
+
+
+def handle_older_version(ver: str) -> None:
+    """Handle an older CV version - just keep sentence_id's in the result"""
+
+    # Get the repo at cutoff date ([TODO] Need to compile real cut-off dates)
+    cutoff_date: str = get_cutoff_date(ver)
+    print(f"=== HANDLE: v{ver} @ {cutoff_date} ===")
+
+    lc_list: list[str] = get_locales_from_cv_dataset(ver)
+    total_locales: int = len(lc_list)
+
+    # Filter out already processed
+    base_tc_dir: str = os.path.join(HERE, c.DATA_DIRNAME, c.TC_DIRNAME)
+    ver_lc_list: list[str] = [
+        f"{ver}|{lc}"
+        for lc in lc_list
+        if not os.path.isfile(
+            os.path.join(base_tc_dir, lc, f"{c.TEXT_CORPUS_FN}_{ver}.tsv")
+        )
+        or conf.FORCE_CREATE_TC_STATS
+    ]
+    num_locales: int = len(ver_lc_list)
+
+    # Handle remaining locales in multi-processing
+    chunk_size: int = min(
+        MAX_BATCH_SIZE,
+        num_locales // PROC_COUNT + (0 if num_locales % PROC_COUNT == 0 else 1),
+    )
+    print(
+        f"Total: {total_locales} Existing: {total_locales-num_locales} Remaining: {num_locales} "
+        + f"Procs: {PROC_COUNT}  chunk_size: {chunk_size}..."
+    )
+
+    if num_locales > 0:
+        git_checkout(c.CV_GITREC, cutoff_date)
+        with mp.Pool(PROC_COUNT) as pool:
+            with tqdm(total=num_locales, desc="") as pbar:
+                for _ in pool.imap_unordered(
+                    handle_old_version_locale, ver_lc_list, chunksize=chunk_size
                 ):
                     pbar.update()
 
@@ -193,17 +305,15 @@ def main() -> None:
     git_checkout(c.CV_GITREC)
     git_clone_or_pull_all()
 
-    # Main loop for all versions - start from newest to get latest text corpus data
-    # cv_version_reversed: list[str] = c.CV_VERSIONS.copy()
-    # cv_version_reversed.reverse()
-    # for inx, ver in enumerate(cv_version_reversed):
-    #     handle_version(inx, ver)
-
     # Do it only for last version (after v17.0)
     handle_last_version()
 
+    # Loop for versions, just to keep sentence_id info
+    for ver in c.CV_VERSIONS:
+        handle_older_version(ver)
+
     # done, revert to main and report
-    # git_checkout(c.CV_GITREC)
+    git_checkout(c.CV_GITREC)
     report_results(g)
 
 

--- a/text_corpus_compile.py
+++ b/text_corpus_compile.py
@@ -256,10 +256,10 @@ def handle_last_version() -> None:
         print(f"Processing: {[x.split(" | ")[1] for x in ver_lc_list]}")
         with mp.Pool(used_proc_count) as pool:
             with tqdm(total=num_locales, desc="Locales") as pbar:
-                for res in pool.imap_unordered(
+                for _res in pool.imap_unordered(
                     handle_last_version_locale, ver_lc_list, chunksize=chunk_size
                 ):
-                    pbar.write(f"Finished: {res}")
+                    # pbar.write(f"Finished: {_res}")
                     pbar.update()
 
     g.total_lc += total_locales
@@ -412,14 +412,14 @@ def handle_older_version(ver: str) -> None:
     )
 
     if num_locales > 0:
-        print(f"Processing: {[x.split(" | ")[1] for x in ver_lc_list]}")
+        # print(f"Processing: {[x.split("|")[1] for x in ver_lc_list]}")
         git_checkout(c.CV_GITREC, cutoff_date)
         with mp.Pool(used_proc_count) as pool:
             with tqdm(total=num_locales, desc="Locales") as pbar:
-                for res in pool.imap_unordered(
+                for _res in pool.imap_unordered(
                     handle_old_version_locale, ver_lc_list, chunksize=chunk_size
                 ):
-                    pbar.write(f"Finished: {res}")
+                    # pbar.write(f"Finished: {_res}")
                     pbar.update()
 
     g.total_lc += total_locales

--- a/typedef.py
+++ b/typedef.py
@@ -1,4 +1,5 @@
 """Type Definitions for cv-tbox Dataset Compiler"""
+
 ###########################################################################
 # typedef.py
 #
@@ -15,10 +16,33 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 
+import pyarrow as pa
+import pandas as pd
+
+#
+# Pandas / ArrowDType definitions to use Arrow backend
+# See: https://pandas.pydata.org/docs/user_guide/pyarrow.html#data-structure-integration
+#
+dtype_pa_uint8 = pd.ArrowDtype(pa.uint8())
+dtype_pa_uint16 = pd.ArrowDtype(pa.uint16())
+dtype_pa_uint32 = pd.ArrowDtype(pa.uint32())
+dtype_pa_uint64 = pd.ArrowDtype(pa.uint64())
+
+dtype_pa_float16 = pd.ArrowDtype(pa.float16())
+dtype_pa_float32 = pd.ArrowDtype(pa.float32())
+dtype_pa_float64 = pd.ArrowDtype(pa.float64())
+
+dtype_pa_str = pd.ArrowDtype(pa.string())
+
+dtype_pa_list_str = pd.ArrowDtype(pa.list_(pa.string()))
+dtype_pa_list_uint8 = pd.ArrowDtype(pa.list_(pa.uint8()))
+dtype_pa_list_uint16 = pd.ArrowDtype(pa.list_(pa.uint16()))
+dtype_pa_list_uint32 = pd.ArrowDtype(pa.list_(pa.uint32()))
+dtype_pa_list_uint64 = pd.ArrowDtype(pa.list_(pa.uint64()))
+
 #
 # Process
 #
-
 
 @dataclass
 class Globals:  # pylint: disable=too-many-instance-attributes
@@ -72,21 +96,28 @@ class GitRec:
 # Text Corpus
 #
 
+
 @dataclass
 class TextCorpusStatsRec:  # pylint: disable=too-many-instance-attributes
     """Record definition for text-corpus statistics"""
 
     ver: str = ""  # cv version code (internal format nn.n, see const.py)
     lc: str = ""  # cv language code
-    algo: str = ""  # splitting algorithm the analysis based on (empty for buckets validated etc)
-    sp: str = ""  # Source of the text-corpus (Empty if TC from server/data, else the bucket/split name)
+    algo: str = (
+        ""  # splitting algorithm the analysis based on (empty for buckets validated etc)
+    )
+    sp: str = (
+        ""  # Source of the text-corpus (Empty if TC from server/data, else the bucket/split name)
+    )
     has_val: bool = False  # if commonvoice-utils has validator for it
     has_phon: bool = False  # if commonvoice-utils has phonemiser for it
     # sentence statistics
     s_cnt: int = 0  # raw sentence count
     uq_s: int = 0  # unique sentence count
     uq_n: int = 0  # unique nomilized sentence count
-    val: int = 0  # How many of the sentences are validated with commonvoice-utils validator - if exists?
+    val: int = (
+        0  # How many of the sentences are validated with commonvoice-utils validator - if exists?
+    )
     # character statistics
     c_sum: int = 0  # total count
     c_avg: float = 0.0  # average (mean)
@@ -107,9 +138,13 @@ class TextCorpusStatsRec:  # pylint: disable=too-many-instance-attributes
     t_freq: list[int] = field(default_factory=lambda: [])  # frequency distribution
     # graphemes & phonemes
     g_cnt: int = 0  # count of different graphemes
-    g_freq: list[list[str | int]] = field(default_factory=lambda: [])  # frequency distribution symbol-count
+    g_freq: list[list[str | int]] = field(
+        default_factory=lambda: []
+    )  # frequency distribution symbol-count
     p_cnt: int = 0  # count of different phonemes
-    p_freq: list[list[str | int]] = field(default_factory=lambda: [])  # frequency distribution symbol-count
+    p_freq: list[list[str | int]] = field(
+        default_factory=lambda: []
+    )  # frequency distribution symbol-count
 
 
 #
@@ -128,8 +163,12 @@ class ReportedStatsRec:  # pylint: disable=too-many-instance-attributes
     rep_avg: float = 0.0  # average (mean)
     rep_med: float = 0.0  # median
     rep_std: float = 0.0  # standard deviation
-    rep_freq: list[int] = field(default_factory=lambda: [])  # frequency distribution for report per sentence
-    rea_freq: list[int] = field(default_factory=lambda: [])  # frequency distribution for reporting reasons
+    rep_freq: list[int] = field(
+        default_factory=lambda: []
+    )  # frequency distribution for report per sentence
+    rea_freq: list[int] = field(
+        default_factory=lambda: []
+    )  # frequency distribution for reporting reasons
 
 
 #

--- a/typedef.py
+++ b/typedef.py
@@ -44,6 +44,7 @@ dtype_pa_list_uint64 = pd.ArrowDtype(pa.list_(pa.uint64()))
 # Process
 #
 
+
 @dataclass
 class Globals:  # pylint: disable=too-many-instance-attributes
     """Class to keep globals in one place"""
@@ -136,15 +137,18 @@ class TextCorpusStatsRec:  # pylint: disable=too-many-instance-attributes
     t_med: float = 0.0  # median
     t_std: float = 0.0  # standard deviation
     t_freq: list[int] = field(default_factory=lambda: [])  # frequency distribution
-    # graphemes & phonemes
-    g_cnt: int = 0  # count of different graphemes
-    g_freq: list[list[str | int]] = field(
-        default_factory=lambda: []
-    )  # frequency distribution symbol-count
-    p_cnt: int = 0  # count of different phonemes
-    p_freq: list[list[str | int]] = field(
-        default_factory=lambda: []
-    )  # frequency distribution symbol-count
+    # graphemes: count, items & frequency distribution
+    g_cnt: int = 0
+    g_items: str = ""  # list[str] = field(default_factory=lambda: [])
+    g_freq: list[int] = field(default_factory=lambda: [])
+    # phonemes: count, items & frequency distribution
+    p_cnt: int = 0
+    p_items: str = ""  # list[str] = field(default_factory=lambda: [])
+    p_freq: list[int] = field(default_factory=lambda: [])
+    # sentence domain statistics
+    dom_cnt: int = 0
+    dom_items: list[str] = field(default_factory=lambda: [])
+    dom_freq: list[int] = field(default_factory=lambda: [])
 
 
 #

--- a/typedef.py
+++ b/typedef.py
@@ -72,15 +72,6 @@ class GitRec:
 # Text Corpus
 #
 
-
-@dataclass
-class TextCorpusRec:
-    """Record definition for combined text-corpora"""
-
-    file: str = ""  # filename in cv repo
-    sentence: str = ""  # original sentence
-
-
 @dataclass
 class TextCorpusStatsRec:  # pylint: disable=too-many-instance-attributes
     """Record definition for text-corpus statistics"""


### PR DESCRIPTION
**Major Changes**:
- Re-map genders back to originals
- Use the new `validated_sentences.tsv` and `sentence_id` field. We now cache the whole/newest text-corpora with some pre-calculations and for previous versions we use cached files only having `sentence_id`'s to reach the data.
- We order descending by file-size, thus increasing the multi-processing usage.
- We started to use pyarrow's dtypes and defined many new type structures for further improvement. We don't use pandas indexes yet thou - needs some testing. We also continue to use "python" engine, "pyarrow" engine is not yet ready for all use cases.
- We added simple sentence_domain statistics, we will add more with data accumulation.
- One major change in my text-corpus analysis: We've been using the whole sentences used recording in buckets/splits and got what is in voice corpus. Now I use unique sentences, regardless of how many times they are recorded - so I now use the text-corpus. This seems more logical.

**Known issues**:
1. There are bugs in the new `validated_sentences.tsv` and we opened several issues in github (See [1](https://github.com/common-voice/common-voice/issues/4406), [2](https://github.com/common-voice/common-voice/issues/4408) and [3](https://github.com/common-voice/common-voice/issues/4421) - the first one is critical). I tried to remedy them in code to some extend, but not all of them.
2. For the former releases (<v17.0), we can only get sentence_id's using sentences, but the sentences got [pre-processed in CorporaCreator](https://github.com/common-voice/CorporaCreator/tree/master/src/corporacreator/preprocessors), so they can have changes. So I could not get the whole text-corpus for these for now, I need to re-implement these in the code.
3. And of course anything between v14.0 - v16.1 will be incomplete (as anything entered through the web interface/write is not there).
